### PR TITLE
Summary: Sample ubuntu config for Virtualhost incorrect

### DIFF
--- a/conf/httpd.conf.ubuntu
+++ b/conf/httpd.conf.ubuntu
@@ -5,7 +5,7 @@
 # 
 # $Id: httpd.conf,v 1.5 2008/01/25 18:03:42 twfy-staging Exp $
 
-<VirtualHost *>
+<VirtualHost *:80>
 ServerName dev.openaustralia.org
 DocumentRoot /var/www/openaustralia/twfy/www/docs/
 


### PR DESCRIPTION
Changesets:
- Minor bugfix: Fix NameVirtualHost that triggers error below:
  /var/log/apache2/error.log:[Sat Sep 20 06:43:55 2014] [warn] NameVirtualHost *:80 has no VirtualHosts
- Apache 2 version under Ubuntu 10.04
  root@e663116e94db:/var/www/openaustralia# apache2ctl -V
  Server version: Apache/2.2.14 (Ubuntu)
  Server built:   Jul 22 2014 14:35:35
  Server's Module Magic Number: 20051115:23
  Server loaded:  APR 1.3.8, APR-Util 1.3.9
  Compiled using: APR 1.3.8, APR-Util 1.3.9
