### PR TITLE
gets php8 working in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,21 @@ LABEL org.openaustralia.image.build.date=$BUILD_DATE \
 
 # Install Apache and PHP
 RUN apt-get update && \
-    apt-get install -y apache2 libapache2-mod-php && \
-    # Install necessary php extensions
-    apt-get install -y libpq-dev php8.3-mysql php8.3-pgsql php8.3-xml php8.3-curl php8.3-mbstring php8.3-zip && \
-    # Enable php extensions.
-    phpenmod pdo_mysql && \
-    # Enable apache modules.
-    a2enmod rewrite php && \
-    # Create dirs for our app.
-    mkdir -p /app/sharedbackup /app/shared/pwdata/members
+    apt-get install -y apache2 libapache2-mod-php
+
+# Install necessary php extensions
+RUN apt-get install -y libpq-dev php8.3-mysql php8.3-pgsql php8.3-xml php8.3-curl php8.3-mbstring php8.3-zip
+
+# Enable php extensions.
+RUN phpenmod pdo_mysql
+
+# Enable apache modules.
+RUN a2enmod rewrite
+
+RUN a2enmod php8.3
+
+# Create dirs for our app.
+RUN mkdir -p /app/sharedbackup /app/shared/pwdata/members
 
 # Set the working directory (default for apache images is /var/www/html)
 WORKDIR /app


### PR DESCRIPTION
## Relevant issue(s)
docker image didn't build 

## What does this do?
* splits the commands so it's easier to see which failed
* changed "php" to "php8.3"

## Why was this needed?
So we can test changes in docker
