### PR TITLE
fix: Sort out that one brace and stop whining about indent whitespace.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,7 @@
     <exclude name="Drupal.NamingConventions.ValidGlobal"/>
     <exclude name="Drupal.NamingConventions.ValidFunctionName"/>
     <exclude name="Drupal.NamingConventions.ValidVariableName"/>
+    <exclude name="Drupal.WhiteSpace.ScopeIndent" />
   </rule>
 
   <!-- Override some settings -->

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1920,7 +1920,7 @@ $displayed_stuff = 0;
         <p><em>Please note that numbers do not measure quality.
                 Also, <?php if ($member['house_disp'] == 1) {
                   echo "Representatives";
-}
+               }
                       else {
                         echo "Senators";
                       } ?> may do other things


### PR DESCRIPTION
## Relevant issue(s)

lint

## What does this do?

Stops currently useless lint warnings about spaces.

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
