### PR TITLE
Feature/add runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ phpcs-verbose:
 	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts
 
 phpcs-ci:
-	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts --report=json --report-file=phpcs-report.json
+	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts --report=full --report=json --report-file=phpcs-report.json

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ lint-ci: lint
 phpcs:
 	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 --report=summary www scripts
 
-phpcs-verbose:
+phpcs-ci phpcs-verbose:
 	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts
 
-phpcs-ci:
-	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts --report=full --report=json --report-file=phpcs-report.json

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.." || exit 1
+
+case "${1:-}" in
+  *.pl)
+    exec perl "$@"
+    ;;
+  *.php)
+    export PATH="/usr/local/bin:/usr/bin:/software/bin:/opt/bin:/opt/php/bin:$PATH"
+    exec php "$@"
+    ;;
+  *)
+    echo "Usage: $0 <script.rb|script.pl|script.php> [args...]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/dailyupdate
+++ b/scripts/dailyupdate
@@ -6,7 +6,7 @@ source consts
 
 # Update links info
 # This loads the links with "mpinfoin.pl links" as well (so we're doing that twice)
-(cd ../../openaustralia-parser; bundle exec parse-member-links.rb)
+../../openaustralia-parser/bin/run parse-member-links.rb
 
 # Update MP info from Public Whip, FaxYourMP and other places
 #cd ~/parlparse/members

--- a/scripts/morningupdate
+++ b/scripts/morningupdate
@@ -39,7 +39,7 @@ date +"%Y-%m-%d %H:%M:%S %Z"
 #$VERBOSE && echo "Rsyncing new data from parlparse"
 #rsync --exclude '.zip' --exclude '.svn' --exclude 'tmp/' --recursive --archive ukparse.kforge.net::parldata /home/fawkes/parldata
 $VERBOSE && echo "Parsing from APH to XML and loading into the database"
-(cd ../../openaustralia-parser; bundle exec parse-speeches.rb previous-working-day)
+../../openaustralia-parser/bin/run parse-speeches.rb previous-working-day
 
 # Load recent new files from XML into the database
 # $VERBOSE && echo "Loading into database"
@@ -70,7 +70,7 @@ EOF
 fi
 
 # Update the XML sitemaps to keep the search engines informed
-(cd ../../openaustralia-parser; bundle exec sitemap.rb)
+../../openaustralia-parser/bin/run sitemap.rb
 
 echo -n "Whole thing done time: "
 date +"%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

* Adds bin/run for parser to call this repos (twfy's) scripts 
* Use parser's bin/run to run its scripts

Rebased on the following PR so we can see why the PHP test fails:
* https://github.com/openaustralia/twfy/pull/63

## Why was this needed?

Because TWFY assumed it knew how to run parser's scripts in particular the ruby version which is no longer true as ruby version changes

## Implementation/Deploy Steps (Optional)

Update openaustralia submodules after merging this PR. Requires this and parser to both have bin/run updates at the same time in openaustraliua

## Notes to reviewer (Optional)
