### PR TITLE
Show what the errors actually are when github/workflow fails!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ phpcs-verbose:
 	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts
 
 phpcs-ci:
-	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts --report=json --report-file=phpcs-report.json
+	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts --report=full --report=json --report-file=phpcs-report.json

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ lint-ci: lint
 phpcs:
 	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 --report=summary www scripts
 
-phpcs-verbose:
+phpcs-ci phpcs-verbose:
 	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts
 
-phpcs-ci:
-	./vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www scripts --report=full --report=json --report-file=phpcs-report.json


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741
* https://github.com/openaustralia/twfy/pull/62 - failing without clear details of why

## What does this do?

Reports what the check was actually complaining about

## Why was this needed?

I don't have PHP installed locally to run the checks with different options and the phpcs-report.json is not saved as an artifact

