### PR TITLE
Replace deprecated create_function with an anonymous function in usort

### DIFF
--- a/www/docs/api/api_getConstituencies.php
+++ b/www/docs/api/api_getConstituencies.php
@@ -148,9 +148,7 @@ function _api_getConstituencies_latitude($lat, $lon, $d) {
         }
     }
     usort($out, function ($a, $b) {
-        if ($a['distance'] > $b['distance']) return 1;
-        if ($a['distance'] < $b['distance']) return -1;
-        return 0;
+        return $a['distance'] <=> $b['distance'];
     });
     return $out;
 }

--- a/www/docs/api/api_getConstituencies.php
+++ b/www/docs/api/api_getConstituencies.php
@@ -147,10 +147,11 @@ function _api_getConstituencies_latitude($lat, $lon, $d) {
             );
         }
     }
-    usort($out, create_function('$a,$b', "
-		if (\$a['distance'] > \$b['distance']) return 1;
-		if (\$a['distance'] < \$b['distance']) return -1;
-		return 0;"));
+    usort($out, function ($a, $b) {
+        if ($a['distance'] > $b['distance']) return 1;
+        if ($a['distance'] < $b['distance']) return -1;
+        return 0;
+    });
     return $out;
 }
 


### PR DESCRIPTION
## Relevant issue(s)
create_function was removed from php

## What does this do?
Uses an anonymous function instead

## Why was this needed?

we are upgrading to php8
