### PR TITLE
fixes call to impode, removing typo

### DIFF
--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -63,7 +63,7 @@ if ($q_method = get_http_var('method')) {
         api_log_call($key);
         api_front_page('Unknown function "' . htmlspecialchars($q_method) .
             '". Possible functions are: ' .
-           implodeoin(', ', array_keys($methods)));
+           implode(', ', array_keys($methods)));
     }
     else {
         if (get_http_var('docs')) {


### PR DESCRIPTION
## What does this do?
fixes what looks like a typo that was meant to call `implode()`

