### PR TITLE
needs access to $db to be able to call db->escape

### DIFF
--- a/www/docs/api/api_getMembers.php
+++ b/www/docs/api/api_getMembers.php
@@ -31,6 +31,7 @@ function _api_getMembers_output($sql)
  */
 function api_getMembers_party($house, $s)
 {
+    $db = new ParlDB();
     global $parties;
     $canon_to_short = array_flip($parties);
     if (isset($canon_to_short[ucwords($s)])) {
@@ -47,6 +48,7 @@ function api_getMembers_party($house, $s)
  */
 function api_getMembers_state($house, $s)
 {
+    $db = new ParlDB();
     global $parties;
     $canon_to_short = array_flip($parties);
     if (isset($canon_to_short[ucwords($s)])) {
@@ -63,6 +65,7 @@ function api_getMembers_state($house, $s)
  */
 function api_getMembers_search($house, $s)
 {
+    $db = new ParlDB();
     $sq = $db->escape($s);
     _api_getMembers_output('select * from member
 		where house = ' . $db->escape($house) . "
@@ -90,6 +93,7 @@ function api_getMembers_date($house, $date)
  */
 function api_getMembers($house, $date = 'now()')
 {
+    $db = new ParlDB();
     _api_getMembers_output('select * from member where house=' . $db->escape($house) .
         ' AND entered_house <= date(' . $date . ') and date(' . $date . ') <= left_house');
 }

--- a/www/docs/api/api_getMembers.php
+++ b/www/docs/api/api_getMembers.php
@@ -31,7 +31,7 @@ function _api_getMembers_output($sql)
  */
 function api_getMembers_party($house, $s)
 {
-    $db = new ParlDB();
+    $db = new ParlDB(); // needed to call db->escape()
     global $parties;
     $canon_to_short = array_flip($parties);
     if (isset($canon_to_short[ucwords($s)])) {
@@ -48,7 +48,7 @@ function api_getMembers_party($house, $s)
  */
 function api_getMembers_state($house, $s)
 {
-    $db = new ParlDB();
+    $db = new ParlDB(); // needed to call db->escape()
     global $parties;
     $canon_to_short = array_flip($parties);
     if (isset($canon_to_short[ucwords($s)])) {
@@ -65,7 +65,7 @@ function api_getMembers_state($house, $s)
  */
 function api_getMembers_search($house, $s)
 {
-    $db = new ParlDB();
+    $db = new ParlDB(); // needed to call db->escape()
     $sq = $db->escape($s);
     _api_getMembers_output('select * from member
 		where house = ' . $db->escape($house) . "
@@ -93,7 +93,7 @@ function api_getMembers_date($house, $date)
  */
 function api_getMembers($house, $date = 'now()')
 {
-    $db = new ParlDB();
+    $db = new ParlDB(); // needed to call db->escape()
     _api_getMembers_output('select * from member where house=' . $db->escape($house) .
         ' AND entered_house <= date(' . $date . ') and date(' . $date . ') <= left_house');
 }


### PR DESCRIPTION
This need re-writing entirely, but not today

## Relevant issue(s)

3 weeks ago, we changed code from `mysql_real_escape_string` to use `$db->escape` (which wraps `mysqli_real_escape_string`)

Among those were some places without access to $db.


## What does this do?

This gives those places a `$db` all of their own.

