### PR TITLE
 replace join() with implode()

### DIFF
--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -308,7 +308,7 @@ function api_output_xml($v, $k = NULL)
             $elt = 'match';
             $api_xml_arr++;
             $out = "<$elt>";
-            $out .= join("</$elt>$verbose<$elt>", array_map('api_output_xml', $v));
+            $out .= implode("</$elt>$verbose<$elt>", array_map('api_output_xml', $v));
             $out .= "</$elt>$verbose";
             return $out;
         }
@@ -333,7 +333,7 @@ function api_output_js($v, $level = 0)
     if (is_array($v)) {
         // PHP arrays are both JS arrays and objects.
         if (count($v) && array_keys($v) === range(0, count($v) - 1)) {
-            return '[' . join(",$verbose", array_map('api_output_js', $v)) . ']';
+            return '[' . implode(",$verbose", array_map('api_output_js', $v)) . ']';
         }
         $out = '{' . $verbose;
         $b = FALSE;

--- a/www/docs/api/api_getMPsInfo.php
+++ b/www/docs/api/api_getMPsInfo.php
@@ -36,7 +36,7 @@ function api_getMPsInfo_id($ids) {
             $safe_ids[] = $id;
         }
     }
-    $ids = join(',', $safe_ids);
+    $ids = implode(',', $safe_ids);
 
     $db = new ParlDB();
     $last_mod = 0;

--- a/www/docs/api/api_getMSP.php
+++ b/www/docs/api/api_getMSP.php
@@ -125,7 +125,7 @@ function _api_getMSP_constituency($constituencies) {
     }
 
     $q = $db->query("SELECT * FROM member
-		WHERE constituency in ('" . join("','", $cons) . "')
+        WHERE constituency in ('" . implode("','", $cons) . "')
 		AND left_reason = 'still_in_office' AND house=4");
     if ($q->rows > 0) {
         _api_getMSP_output($q);

--- a/www/docs/departments/questions.php
+++ b/www/docs/departments/questions.php
@@ -27,7 +27,7 @@ if (!$dept) {
     print '<h3>Written Questions from the past week</h3>';
     $q = $db->query('select gid,body from hansard,epobject
 		where hansard.epobject_id=epobject.epobject_id and major=3 and subsection_id=0
-		and section_id in (' . join(',', $ids) . ')
+    and section_id in (' . implode(',', $ids) . ')
 		order by body');
     print '<ul>';
     for ($i = 0; $i < $q->rows(); $i++) {

--- a/www/docs/departments/statements.php
+++ b/www/docs/departments/statements.php
@@ -27,7 +27,7 @@ if (!$dept) {
     print '<h3>Written Ministerial Statements from the past week</h3>';
     $q = $db->query('select gid,body from hansard,epobject
 		where hansard.epobject_id=epobject.epobject_id and major=4 and subsection_id=0
-		and section_id in (' . join(',', $ids) . ')
+    and section_id in (' . implode(',', $ids) . ')
 		order by body');
     print '<ul>';
     for ($i = 0; $i < $q->rows(); $i++) {

--- a/www/docs/email/index.php
+++ b/www/docs/email/index.php
@@ -38,9 +38,9 @@ if (!$sender_name) {
     $errors[] = "If you don't give us your name, we can't tell the recipient who sent them the link. We won't store it or use for any other purpose than sending this email.";
 }
 
-if (sizeof($errors)) {
+if (count($errors)) {
     print '<p>Please correct the following errors:</p>';
-    print '<ul><li>' . join('</li> <li>', $errors) . '</li></ul><br>';
+    print '<ul><li>' . implode('</li> <li>', $errors) . '</li></ul><br>';
     ?>
     <form action="./" method="post">
         <p>

--- a/www/docs/regmem/index.php
+++ b/www/docs/regmem/index.php
@@ -441,9 +441,9 @@ function clean_diff($old, $new) {
     if (!count($r) && !count($a)) {
         return '';
     }
-    $r = join("\n", $r);
+    $r = implode("\n", $r);
     $r = $r ? '<td class="r"><ul>' . $r . '</ul></td>' : '<td>&nbsp;</td>';
-    $a = join("\n", $a);
+    $a = implode("\n", $a);
     $a = $a ? '<td class="a"><ul>' . $a . '</ul></td>' : '<td>&nbsp;</td>';
     $diff = '<tr>' . $r . $a . '</tr>';
     $diff = preg_replace('#<item.*?>(.*?)</item>#', '<li>$1</li>', $diff);

--- a/www/docs/user/index.php
+++ b/www/docs/user/index.php
@@ -1144,10 +1144,10 @@ function display_user($user_id = "") {
                     if (strpos($search_url, 'pid=') !== FALSE) {
                         $search_url .= '&';
                     }
-                    $search_url .= "s=" . join("+", $search_keywords);
+                    $search_url .= "s=" . implode("+", $search_keywords);
                 }
 
-                $display_criteria = join(' ', $display_terms);
+                $display_criteria = implode(' ', $display_terms);
                 $token = $row['alert_id'] . '-' . $row['registrationtoken'];
                 if (!$row['confirmed']) {
                     $action = '<a href="' . WEBPATH . 'A/' . $token . '">Confirm</a>';

--- a/www/docs/wikipedia/index.php
+++ b/www/docs/wikipedia/index.php
@@ -44,7 +44,7 @@ $PAGE->stripe_start();
         }
         $out[] = $o;
     }
-    print join(' | ', $out);
+    print implode(' | ', $out);
     ?>
 </p>
 <style type="text/css">

--- a/www/includes/constituencies.php
+++ b/www/includes/constituencies.php
@@ -41,7 +41,7 @@ function normalise_constituency_names($names) {
     $q = $db->query('select constituency.name as name,c_main.name as canonical_name
 		from constituency, constituency as c_main
 		where constituency.cons_id = c_main.cons_id
-		and c_main.main_name and constituency.name in ("' . join('","', array_values($names)) .
+		and c_main.main_name and constituency.name in ("' . implode('","', array_values($names)) .
         '") and constituency.from_date <= date(now())
 		and date(now()) <= constituency.to_date');
     $lookup = [];

--- a/www/includes/easyparliament/alert.php
+++ b/www/includes/easyparliament/alert.php
@@ -117,7 +117,7 @@ function alert_details_to_criteria($details) {
     if ($details['pid']) {
         $criteria[] = 'speaker:' . $details['pid'];
     }
-    $criteria = join(' ', $criteria);
+    $criteria = implode(' ', $criteria);
     return $criteria;
 }
 
@@ -203,10 +203,6 @@ class ALERT {
 
         // Get all the data that's to be returned.
         $tmpdata = $this->fetch($confirmed, $deleted);
-        // Foreach ($tmpdata as $n => $data)
-        //                {
-        //                    echo "Alert: " . $data['email'] . " and " . $data['criteria'];
-        //                }.
     }
 
     /**
@@ -546,7 +542,7 @@ class ALERT {
         }
         $criteria = '';
         if (count($words)) {
-            $criteria .= ($html ? '<li>' : '* ') . 'Containing the ' . make_plural('word', count($words)) . ': ' . join(' ', $words) . ($html ? '</li>' : '') . "\n";
+            $criteria .= ($html ? '<li>' : '* ') . 'Containing the ' . make_plural('word', count($words)) . ': ' . implode(' ', $words) . ($html ? '</li>' : '') . "\n";
         }
         if ($spokenby) {
             $criteria .= ($html ? '<li>' : '* ') . "Spoken by $spokenby" . ($html ? '</li>' : '') . "\n";

--- a/www/includes/easyparliament/hansardlist.php
+++ b/www/includes/easyparliament/hansardlist.php
@@ -3290,7 +3290,7 @@ class StandingCommittee extends DEBATELIST {
             $bills[$q->field($i, 'id')] = $q->field($i, 'title');
         }
         $q = $this->db->query('select minor,count(*) as c from hansard where major=6 and htype=12
-			and minor in (' . join(',', array_keys($bills)) . ')
+			and minor in (' . implode(',', array_keys($bills)) . ')
 			group by minor');
         $counts = [];
         // $comments = array();

--- a/www/includes/easyparliament/searchengine.php
+++ b/www/includes/easyparliament/searchengine.php
@@ -122,7 +122,7 @@ class SEARCHENGINE {
             if (strpos($word, ':') !== FALSE) {
                 $items = explode(":", strtolower($word));
                 $type = $items[0];
-                $value = join(":", array_slice($items, 1));
+                $value = implode(":", array_slice($items, 1));
                 if ($type == "section") {
                     // Adding section:representatives but not removing debates & debate in case they are used anywhere.
                     if ($value == "debates" || $value == "debate" || $value == "representatives") {
@@ -186,7 +186,7 @@ else {
      *
      */
     public function make_phrase($phrasearray) {
-        return '"' . join(' ', $phrasearray) . '"';
+        return '"' . implode(' ', $phrasearray) . '"';
     }
 
     /**
@@ -208,7 +208,7 @@ else {
             $description .= " the " . make_plural("word", count($this->words));
             $description .= " '";
             if (count($this->words) > 2) {
-                $description .= join("', '", array_slice($this->words, 0, -2));
+                $description .= implode("', '", array_slice($this->words, 0, -2));
                 $description .= "', '";
                 $description .= $this->words[count($this->words) - 2] . "', and '" . $this->words[count($this->words) - 1];
             }
@@ -231,7 +231,7 @@ else {
                 $description .= " and";
             }
             $description .= " the " . make_plural("phrase", count($this->phrases)) . " ";
-            $description .= join(', ', array_map([$this, "make_phrase"], $this->phrases));
+            $description .= implode(', ', array_map([$this, "make_phrase"], $this->phrases));
         }
 
         if (count($this->excluded) > 0) {
@@ -242,17 +242,8 @@ else {
                 $description .= " excluding";
             }
             $description .= " the " . make_plural("word", count($this->excluded));
-            $description .= " '" . join(' ', $this->excluded) . "'";
+            $description .= " '" . implode(' ', $this->excluded) . "'";
         }
-
-        /*        if (count($this->rough) > 0) {
-        if ($description == "") {
-        if ($long) {
-        $description .= " containing ";
-        }
-        }
-        $description .= " roughly words '" . join(' ', $this->rough) . "'";
-        } */
 
         $major = [];
         $speaker = [];
@@ -299,11 +290,11 @@ else {
                 $PAGE->error_message("Unknown search prefix '$items[0]' ignored");
             }
         }
-        if (sizeof($speaker)) {
-            $description .= ' by ' . join(' or ', $speaker);
+        if (count($speaker)) {
+            $description .= ' by ' . implode(' or ', $speaker);
         }
-        if (sizeof($major)) {
-            $description .= ' in ' . join(' or ', $major);
+        if (count($major)) {
+            $description .= ' in ' . implode(' or ', $major);
         }
 
         return trim($description);
@@ -339,7 +330,7 @@ else {
     public function query_remade() {
         $remade = [];
         foreach ($this->phrases as $phrase) {
-            $remade[] = '"' . join(' ', $phrase) . '"';
+            $remade[] = '"' . implode(' ', $phrase) . '"';
         }
         if ($this->words) {
             $remade = array_merge($remade, $this->words);
@@ -356,15 +347,14 @@ else {
         }
         foreach ($prefixes as $prefix) {
             if (count($prefix)) {
-                $remade[] = '(' . join(' OR ', $prefix) . ')';
+                $remade[] = '(' . implode(' OR ', $prefix) . ')';
             }
         }
 
-        $query = trim(join(' AND ', $remade));
+        $query = trim(implode(' AND ', $remade));
         if ($this->excluded) {
-            $query .= ' NOT (' . join(' AND ', $this->excluded) . ')';
+            $query .= ' NOT (' . implode(' AND ', $this->excluded) . ')';
         }
-        // $remade .= ' ' . join(' ', array_map(array($this, "stem"), $this->rough));
         return $query;
     }
 
@@ -535,7 +525,7 @@ else {
             // array_push($replacewords, "\\1<span class=\"hi\">\\2</span>\\3");.
         }
         foreach ($this->phrases as $phrase) {
-            $phrasematch = join($phrase, '[^' . $this->wordchars . ']+');
+            $phrasematch = implode($phrase, '[^' . $this->wordchars . ']+');
             array_push($findwords, "/\b($phrasematch)\b/i");
             $replacewords[] = "<span class=\"hi\">\\1</span>";
         }
@@ -562,7 +552,7 @@ else {
 
         // Look for phrases.
         foreach ($this->phrases as $phrase) {
-            $phrasematch = join($phrase, '[^' . $this->wordchars . ']+');
+            $phrasematch = implode($phrase, '[^' . $this->wordchars . ']+');
             if (preg_match('/([^' . $this->wordchars . ']' . $phrasematch . '[^' . $this->wordchars . '])/', $lcbody, $matches)) {
                 $wordpos = strpos($lcbody, $matches[0]);
                 if ($wordpos) {
@@ -674,7 +664,7 @@ function search_by_usage($search, $house = 0) {
 
     // Fetch all the speakers of the results, count them up and get min/max date usage.
     $speaker_count = [];
-    $gids = join('","', $gids);
+    $gids = implode('","', $gids);
     $db = new ParlDB();
     $q = $db->query('SELECT gid,speaker_id,hdate FROM hansard WHERE gid IN ("' . $gids . '")');
     for ($n = 0; $n < $q->rows(); $n++) {
@@ -698,7 +688,7 @@ function search_by_usage($search, $house = 0) {
 
     // Fetch details of all the speakers.
     if (count($speaker_count)) {
-        $speaker_ids = join(',', array_keys($speaker_count));
+        $speaker_ids = implode(',', array_keys($speaker_count));
         $q = $db->query('SELECT member_id, person_id, title,first_name,last_name,constituency,house,party,
                                 moffice_id, dept, position, from_date, to_date, left_house
                             FROM member LEFT JOIN moffice ON member.person_id = moffice.person

--- a/www/includes/easyparliament/templates/html/people_peers.php
+++ b/www/includes/easyparliament/templates/html/people_peers.php
@@ -118,13 +118,14 @@ function render_peers_row($peer, &$style, $order, $URL)
         <td class="row-<?php echo $style; ?>"><?php echo $peer['constituency'] ?></td>
         <td class="row-<?php echo $style; ?>">
             <?php
-            if (is_array($peer['dept']))
-                print join('<br>', array_map('manymins', $peer['pos'], $peer['dept']));
-            elseif ($peer['dept'])
+            if (is_array($peer['dept'])) {
+                print implode('<br>', array_map('manymins', $peer['pos'], $peer['dept']));
+            } elseif ($peer['dept']) {
                 print prettify_office($peer['pos'], $peer['dept']);
-            else
-                print '&nbsp;'
-                    ?>
+            } else {
+                print '&nbsp;';
+            }
+            ?>
             </td>
 
         <?php if ($order == 'debates') { ?>

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -1112,7 +1112,7 @@ function major_summary($data, $limit = "") {
 				FROM hansard,epobject
 				WHERE hansard.epobject_id = epobject.epobject_id AND section_id=0
 				AND hdate="' . $date . '"
-				AND major IN (' . join(',', $printed_majors) . ')
+				AND major IN (' . implode(',', $printed_majors) . ')
 				ORDER BY major desc, hpos' . $limitsql);
         $current_major = 0;
         for ($i = 0; $i < $q->rows(); $i++) {

--- a/www/includes/wikipedia.php
+++ b/www/includes/wikipedia.php
@@ -36,7 +36,7 @@ function lensort($a, $b) {
 function wikipedize($source) {
     $was_array = FALSE;
     if (is_array($source)) {
-        $source = join('|||', $source);
+        $source = implode('|||', $source);
         $was_array = TRUE;
     }
 
@@ -79,7 +79,7 @@ function wikipedize($source) {
     $matched = [];
     $db = new ParlDB();
     $source = explode('|||', $source);
-    $q = $db->query("SELECT title FROM titles WHERE title IN ('" . join("','", $phrases) . "')");
+    $q = $db->query("SELECT title FROM titles WHERE title IN ('" . implode("','", $phrases) . "')");
     for ($i = 0; $i < $q->rows(); $i++) {
         $wikistring = $q->field($i, 'title');
         $phrase = str_replace('_', ' ', $wikistring);
@@ -99,7 +99,7 @@ function wikipedize($source) {
     }
 
     if (!$was_array) {
-        $source = join('|||', $source);
+        $source = implode('|||', $source);
     }
 
     return $source;


### PR DESCRIPTION
## Relevant issue(s)

Splitting up PR #70. that PR is a green lint pass, but it's so big it's gonna be difficult to review.

## What does this do?
replaces `join()` with `implode()`

In some locations, also deleting commented out code that's been commented out for over a decade.
And fixes some `{ }` around if/else if they were right next to the implode()

## Why was this needed?

PHP5 to 8 upgrade
