### PR TITLE
update function declarations to use consistent formatting

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,12 +17,19 @@
     <exclude name="Drupal.Classes.ClassFileName"/>
     <exclude name="Drupal.Commenting.DocComment"/>
     <exclude name="Drupal.Commenting.VariableComment"/>
+    <exclude name="Drupal.ControlStructures.ControlSignature" />
     <exclude name="Drupal.NamingConventions.ValidClassName"/>
     <exclude name="Drupal.NamingConventions.ValidGlobal"/>
     <exclude name="Drupal.NamingConventions.ValidFunctionName"/>
     <exclude name="Drupal.NamingConventions.ValidVariableName"/>
     <exclude name="Drupal.WhiteSpace.ScopeIndent" />
   </rule>
+
+  <!-- Require } else { on same line (K&R style) -->
+  <rule ref="PEAR.ControlStructures.ControlSignature" />
+
+  <!-- Require function opening { on same line (K&R style) -->
+  <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
 
   <!-- Override some settings -->
   <rule ref="Drupal.WhiteSpace.ScopeIndent">

--- a/scripts/alertgonemps.php
+++ b/scripts/alertgonemps.php
@@ -85,8 +85,7 @@ print "Email lookups: $registered registered, $unregistered unregistered\n";
 /**
  *
  */
-function write_and_send_email($email, $user_id, $data)
-{
+function write_and_send_email($email, $user_id, $data) {
     global $globalsuccess, $out, $sentemails, $nomail;
 
     if ($user_id) {

--- a/scripts/alertmailer.php
+++ b/scripts/alertmailer.php
@@ -10,8 +10,7 @@
 /**
  *
  */
-function mlog($message)
-{
+function mlog($message): void {
     print $message;
 }
 
@@ -256,8 +255,7 @@ mlog(date('r') . "\n");
 /**
  *
  */
-function sort_by_stuff($a, $b)
-{
+function sort_by_stuff($a, $b) {
     if ($a['major'] > $b['major']) {
         return 1;
     }
@@ -281,8 +279,7 @@ function sort_by_stuff($a, $b)
 /**
  *
  */
-function write_and_send_email($email, $user_id, $data)
-{
+function write_and_send_email($email, $user_id, $data) {
     global $globalsuccess, $sentemails, $nomail, $start_time;
 
     $data .= '====================' . "\n\n";

--- a/scripts/mprss.php
+++ b/scripts/mprss.php
@@ -62,8 +62,7 @@ for ($personrow = 0; $personrow < $q->rows(); $personrow++) {
             $hdate = format_date($row['hdate'], 'Y-m-d');
             if ($row['htime'] != NULL) {
                 $htime = format_time($row['htime'], 'H:i:s');
-            }
-            else {
+            } else {
                 $htime = '00:00:00';
             }
 

--- a/scripts/wranstats.php
+++ b/scripts/wranstats.php
@@ -45,8 +45,7 @@ for ($i = 0; $i < $q->rows(); $i++) {
 			 	and hansard.speaker_id=member.member_id
 				and person_id = ' . $p_id . ' and major=3 and minor=2 and left_house>curdate())');
         $wrans_with_votes = $qq->rows();
-    }
-    else {
+    } else {
         $wrans_with_votes = '';
     }
     print "$name\t$con\t$wrans\t$wrans_with_votes\t$yes\t$no\n";

--- a/www/docs/addlink/index.php
+++ b/www/docs/addlink/index.php
@@ -19,8 +19,7 @@ if ((get_http_var('g') != '') && (get_http_var('previewterm') == '')) {
     // We're searching for something.
     $args['s'] = filter_user_input(get_http_var('g'), 'strict');
     $GLOSSARY = new GLOSSARY($args);
-}
-else {
+} else {
     $args['sort'] = "regexp_replace";
     $GLOSSARY = new GLOSSARY($args);
     $args['s'] = filter_user_input(get_http_var('g'), 'strict');
@@ -47,12 +46,10 @@ if (get_http_var("submitterm") != '') {
         // $success will be the editqueue_id().
         print "<h4>All good so far...</h4><p>Your definition for <strong>&quot;" . $data['title'] . "&quot;</strong> now awaits moderator approval or somesuch thing...</p>";
         $PAGE->glossary_links();
-    }
-    else {
+    } else {
         $PAGE->error_message("Sorry, there was an error and we were unable to add your Glossary item.");
     }
-}
-elseif (get_http_var("previewterm") != '') {
+} elseif (get_http_var("previewterm") != '') {
     // We're previewing a Glossary definition.
 
     if (get_http_var('definition') != '') {
@@ -76,8 +73,7 @@ elseif (get_http_var("previewterm") != '') {
         // Then, in case they aren't happy with it, show them the form again.
         $PAGE->glossary_add_definition_form($args);
     }
-}
-elseif ($GLOSSARY->query != '') {
+} elseif ($GLOSSARY->query != '') {
     // Deal with all the various searching possiblities...
 
     if ($GLOSSARY->num_search_matches >= 1) {
@@ -95,19 +91,16 @@ elseif ($GLOSSARY->query != '') {
             if ($args['count']) {
                 // Display the Add definition form.
                 $PAGE->glossary_add_link_form($args);
-            }
-            else {
+            } else {
                 print "<h4>No dice!</h4><p>Much as we'd love you to add a definition for <strong></strong>, it doesn't seem to appear in hansard at all...</p>";
                 $PAGE->glossary_links();
             }
-        }
-        else {
+        } else {
             print "<h4>Humdinger!</h4><p>it would appear that you aren't allowed to add glossary terms. How odd...</p>";
             $PAGE->glossary_links();
         }
     }
-}
-else {
+} else {
 
     $PAGE->stripe_start();
 

--- a/www/docs/addterm/index.php
+++ b/www/docs/addterm/index.php
@@ -20,8 +20,7 @@ if ((get_http_var('g') != '') && (get_http_var('previewterm') == '')) {
     // We're searching for something.
     $args['s'] = filter_user_input(get_http_var('g'), 'strict');
     $GLOSSARY = new GLOSSARY($args);
-}
-else {
+} else {
     $args['sort'] = "regexp_replace";
     $GLOSSARY = new GLOSSARY($args);
     $args['s'] = filter_user_input(get_http_var('g'), 'strict');
@@ -71,12 +70,10 @@ if (get_http_var("submitterm") != '') {
         print "<h4>Thank you for your help</h4><p>Your definition for <strong>&quot;" . $data['title'] . "&quot;</strong> has been submitted and awaits moderator approval. If every thing is well and good, it should appear on the site within the next day or so.</p>";
         print "<p>You can browse the exising glossary below:</p>";
         $PAGE->glossary_atoz($GLOSSARY);
-    }
-    else {
+    } else {
         $PAGE->error_message("Sorry, there was an error and we were unable to add your Glossary item.");
     }
-}
-elseif (get_http_var("previewterm") != '') {
+} elseif (get_http_var("previewterm") != '') {
     // We're previewing a Glossary definition.
 
     if (get_http_var('definition') != '') {
@@ -104,8 +101,7 @@ elseif (get_http_var("previewterm") != '') {
     $PAGE->stripe_end();
 
 
-}
-elseif ($GLOSSARY->query != '') {
+} elseif ($GLOSSARY->query != '') {
     // Deal with all the various searching possiblities...
 
     if ($GLOSSARY->num_search_matches >= 1) {
@@ -150,8 +146,7 @@ elseif ($GLOSSARY->query != '') {
             print "<p><a href=\"#definition\">Back to form</a></p>";
         }
     }
-}
-else {
+} else {
     // We just arrived here empty handed...
 
     if (isset($error_message)) {

--- a/www/docs/admin/alerts.php
+++ b/www/docs/admin/alerts.php
@@ -68,8 +68,7 @@ $PAGE->page_end();
 /**
  *
  */
-function generate_rows($q)
-{
+function generate_rows($q) {
     global $db;
     $rows = [];
     $USERURL = new URL('userview');

--- a/www/docs/admin/glossary.php
+++ b/www/docs/admin/glossary.php
@@ -34,8 +34,7 @@ if (get_http_var('approve')) {
         'epobject_type' => 2
     ];
     $EDITQUEUE->approve($data);
-}
-elseif (get_http_var('decline')) {
+} elseif (get_http_var('decline')) {
     $decline = [get_http_var('decline')];
     // Dump all declined items.
     $data = [
@@ -43,8 +42,7 @@ elseif (get_http_var('decline')) {
         'epobject_type' => 2
     ];
     $EDITQUEUE->decline($data);
-}
-elseif (get_http_var('delete_confirm')) {
+} elseif (get_http_var('delete_confirm')) {
     $delete_id = get_http_var('delete_confirm');
     // Delete the existing glossary entry.
     $GLOSSARY->delete($delete_id);

--- a/www/docs/admin/glossary_pending.php
+++ b/www/docs/admin/glossary_pending.php
@@ -36,8 +36,7 @@ if (get_http_var('approve')) {
         'epobject_type' => 2
     ];
     $EDITQUEUE->approve($data);
-}
-elseif (get_http_var('decline')) {
+} elseif (get_http_var('decline')) {
     $decline = [get_http_var('decline')];
     // Dump all declined items.
     $data = [
@@ -61,15 +60,13 @@ if (get_http_var('modify') && (!get_http_var('submitterm'))) {
     if (get_http_var('previewterm')) {
         $body  = get_http_var('definition');
         $title = get_http_var('g');
-    }
-    else {
+    } else {
         $body = $EDITQUEUE->pending[$glossary_id]['body'];
         $title = $EDITQUEUE->pending[$glossary_id]['title'];
     }
     if (get_http_var('wikiguess')) {
         $checked = " checked";
-    }
-    else {
+    } else {
         $checked = "";
     }
 
@@ -117,8 +114,7 @@ if (get_http_var('modify') && (!get_http_var('submitterm'))) {
 
     $PAGE->glossary_display_term($GLOSSARY);
 
-}
-else {
+} else {
 
     // Add a modification to the database.
     if (get_http_var('submitterm') && get_http_var('modify')) {
@@ -134,8 +130,7 @@ else {
     if ($EDITQUEUE->pending_count) {
         print "<h3>" . $EDITQUEUE->pending_count . " Pending Glossary terms</h3>";
         $EDITQUEUE->display("pending");
-    }
-    else {
+    } else {
         print "<h3>Nothing pending, tap your fingers awhile.</h3>";
     }
 }

--- a/www/docs/admin/index.php
+++ b/www/docs/admin/index.php
@@ -74,8 +74,7 @@ for ($row = 0; $row < $q->rows(); $row++) {
         $confirmed = 'Yes';
         $name = '<a href="' . $USERURL->generate() . '">' . htmlspecialchars($q->field($row, 'firstname'))
         . ' ' . htmlspecialchars($q->field($row, 'lastname')) . '</a>';
-    }
-    else {
+    } else {
         $confirmed = 'No';
         $name = htmlspecialchars($q->field($row, 'firstname') . ' ' . $q->field($row, 'lastname'));
     }

--- a/www/docs/admin/report.php
+++ b/www/docs/admin/report.php
@@ -65,8 +65,7 @@ if ($REPORT->locked() && $REPORT->lockedby() != $THEUSER->user_id()) {
     $PAGE->page_end();
     exit;
 
-}
-elseif ($THEUSER->is_able_to('deletecomment')) {
+} elseif ($THEUSER->is_able_to('deletecomment')) {
 
     // Prevent anyone else from editing this report.
     $REPORT->lock();
@@ -85,8 +84,7 @@ if (get_http_var('resolve') != '') {
     resolve($REPORT, $COMMENT);
 
 
-}
-elseif (get_http_var('takingaction') == 'true') {
+} elseif (get_http_var('takingaction') == 'true') {
 
     // The user has chosen to delete or not delete the comment.
     // So we need to let them prepare the appropriate emails.
@@ -99,14 +97,12 @@ elseif (get_http_var('takingaction') == 'true') {
     if (get_http_var('yes') != '') {
         prepare_emails_for_deleting($REPORT, $COMMENT, $FORMURL);
 
-    }
-    else {
+    } else {
         prepare_emails_for_not_deleting($REPORT, $COMMENT, $FORMURL);
     }
 
 
-}
-else {
+} else {
 
 
     // The user is viewing a comment and its report.
@@ -255,8 +251,7 @@ function resolve($REPORT, $COMMENT) {
 
     if (get_http_var('deletecomment') == 'true') {
         $upheld = TRUE;
-    }
-    else {
+    } else {
         $upheld = FALSE;
     }
 
@@ -279,8 +274,7 @@ function resolve($REPORT, $COMMENT) {
                 $USER = new USER();
                 $USER->init($REPORT->user_id());
                 $email = $USER->email();
-            }
-            else {
+            } else {
                 // Non-logged-in user; they should have left their address.
                 $email = $REPORT->email();
             }
@@ -299,8 +293,7 @@ function resolve($REPORT, $COMMENT) {
             if ($upheld == TRUE) {
                 $data['template'] = 'report_upheld';
 
-            }
-            else {
+            } else {
                 $data['template'] = 'report_declined';
                 $merge['COMMENTURL'] = 'http://' . DOMAIN . $COMMENT->url();
                 $merge['REASON'] = get_http_var('declinedreason');
@@ -310,8 +303,7 @@ function resolve($REPORT, $COMMENT) {
 
             if ($success) {
                 print "<p>An email has been sent to the person who made the report.</p>\n";
-            }
-            else {
+            } else {
                 $PAGE->error_message("Failed when sending an email to the person who made the report.");
             }
 
@@ -345,8 +337,7 @@ function resolve($REPORT, $COMMENT) {
 
             if ($success) {
                 print "<p>An email has been sent to the person who posted the comment.</p>\n";
-            }
-            else {
+            } else {
                 $PAGE->error_message("Failed when sending an email to the person who posted the comment.");
             }
         }

--- a/www/docs/alert/confirm/index.php
+++ b/www/docs/alert/confirm/index.php
@@ -44,8 +44,7 @@ $success = $ALERT->confirm(get_http_var('t'));
 
 if ($success) {
     confirm_success($ALERT);
-}
-else {
+} else {
     confirm_error();
 }
 

--- a/www/docs/alert/delete/index.php
+++ b/www/docs/alert/delete/index.php
@@ -42,8 +42,7 @@ $success = $ALERT->delete(get_http_var('t'));
 
 if ($success) {
     delete_success();
-}
-else {
+} else {
     delete_error();
 }
 

--- a/www/docs/alert/index.php
+++ b/www/docs/alert/index.php
@@ -30,8 +30,7 @@ $details = [];
 
 if ($THEUSER->loggedin()) {
     $details['email'] = $THEUSER->email();
-}
-else {
+} else {
     $details["email"] = trim(get_http_var("email"));
 }
 
@@ -55,8 +54,7 @@ if (
         || ($details['keyword'] && $details['pid']))
 ) {
     add_alert($details);
-}
-else {
+} else {
     $PAGE->page_start();
     $PAGE->stripe_start();
     $PAGE->block_start(['id' => 'alerts', 'title' => 'Request an OpenAustralia.org Email Alert']);
@@ -87,8 +85,7 @@ function check_input($details) {
     // Check email address is valid and unique.
     if ($details["email"] == "") {
         $errors["email"] = "Please enter your email address";
-    }
-    elseif (!validate_email($details["email"])) {
+    } elseif (!validate_email($details["email"])) {
         // validate_email() is in includes/utilities.php.
         $errors["email"] = "Please enter a valid email address";
     }
@@ -129,11 +126,9 @@ function add_alert($details) {
         }
         $extra = 'from_' . $site . '=1';
         $confirm = FALSE;
-    }
-    elseif ($THEUSER->loggedin()) {
+    } elseif ($THEUSER->loggedin()) {
         $confirm = FALSE;
-    }
-    else {
+    } else {
         $confirm = TRUE;
     }
 
@@ -155,12 +150,10 @@ function add_alert($details) {
             $criteria = $MEMBER->full_name();
             if ($details['keyword']) {
                 $criteria .= ' mentions \'' . $details['keyword'] . '\'';
-            }
-            else {
+            } else {
                 $criteria .= ' contributes';
             }
-        }
-        elseif ($details['keyword']) {
+        } elseif ($details['keyword']) {
             $criteria = '\'' . $details['keyword'] . '\' is mentioned';
         }
         $message = [
@@ -168,21 +161,18 @@ function add_alert($details) {
             'text' => 'You will now receive email alerts on any day when ' . $criteria . ' in parliament.'
         ];
         $advert = TRUE;
-    }
-    elseif ($success > 0) {
+    } elseif ($success > 0) {
         $message = [
             'title' => "We're nearly done...",
             'text' => "You should receive an email shortly which will contain a link. You will need to follow that link to confirm your email address to receive the alert. Thanks."
         ];
-    }
-    elseif ($success == -2) {
+    } elseif ($success == -2) {
         $message = [
             'title' => 'You already have this alert',
             'text' => 'You already appear to be subscribed to this email alert, so we have not signed you up to it again.'
         ];
         $advert = TRUE;
-    }
-    else {
+    } else {
         $message = [
             'title' => "This alert has not been accepted",
             'text' => "Sorry, we were unable to create this alert. Please <a href=\"mailto:" . CONTACTEMAIL . "\">let us know</a>. Thanks."
@@ -306,12 +296,15 @@ function display_form($details = [], $errors = []) {
                 If you join or log in, you won't need to confirm your email address for every alert you set.
             </div>
         <?php }
-        if (get_http_var('sign'))
+        if (get_http_var('sign')) {
             echo '<input type="hidden" name="sign" value="' . htmlspecialchars(get_http_var('sign')) . '">';
-        if (get_http_var('site'))
+        }
+        if (get_http_var('site')) {
             echo '<input type="hidden" name="site" value="' . htmlspecialchars(get_http_var('site')) . '">';
+        }
         // MJ OA-437 Recommendations.
-        if (get_http_var('r'))
+        if (get_http_var('r')) {
             echo '<input type="hidden" name="r" value="' . htmlspecialchars(get_http_var('r')) . '">';
+        }
         echo '<input type="hidden" name="submitted" value="true"> </form>';
 }

--- a/www/docs/alert/undelete/index.php
+++ b/www/docs/alert/undelete/index.php
@@ -34,8 +34,7 @@ $success = $ALERT->confirm(get_http_var('t'));
 
 if ($success) {
     undelete_success();
-}
-else {
+} else {
     undelete_error();
 }
 

--- a/www/docs/api/api_convertURL.php
+++ b/www/docs/api/api_convertURL.php
@@ -7,8 +7,7 @@
 /**
  *
  */
-function api_convertURL_front()
-{
+function api_convertURL_front() {
     ?>
     <p><big>Converts an aph.gov.au Hansard URL into an OpenAustralia one, if possible.</big></p>
 
@@ -46,8 +45,7 @@ function api_convertURL_front()
 /**
  * Very similar to function in hansardlist.php, but separated .
  */
-function get_listurl($q)
-{
+function get_listurl($q) {
     global $hansardmajors;
     $id_data = [
         'gid' => fix_gid_from_db($q->field(0, 'gid')),
@@ -81,8 +79,7 @@ function get_listurl($q)
 /**
  *
  */
-function api_converturl_url_output($q)
-{
+function api_converturl_url_output($q) {
     $gid = $q->field(0, 'gid');
     $url = get_listurl($q);
     $output = [
@@ -95,8 +92,7 @@ function api_converturl_url_output($q)
 /**
  *
  */
-function api_converturl_url($url)
-{
+function api_converturl_url($url) {
     $db = new ParlDB();
     $url_nohash = preg_replace('/#.*/', '', $url);
     $q = $db->query('select gid,major,htype,subsection_id from hansard where source_url = "' . $db->escape($url) . '" order by gid limit 1');

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -125,8 +125,7 @@ $methods = [
 /**
  * Key-related functions.
  */
-function api_log_call($key)
-{
+function api_log_call($key) {
     if ($key == 'DOCS') {
         return;
     }
@@ -141,8 +140,7 @@ function api_log_call($key)
 /**
  *
  */
-function api_check_key($key)
-{
+function api_check_key($key) {
     $db = new ParlDB();
     $q = $db->query('SELECT user_id FROM api_key WHERE api_key="' . $db->escape($key) . '"');
     if (!$q->rows()) {
@@ -154,15 +152,13 @@ function api_check_key($key)
 /**
  *
  */
-function api_key_current_message()
-{
+function api_key_current_message() {
 }
 
 /**
  * Front-end sidebar of all methods.
  */
-function api_sidebar()
-{
+function api_sidebar() {
     global $methods;
     $sidebar = '<div class="block"><h4>API Functions</h4> <div class="blockbody"><ul>';
     foreach ($methods as $method => $data) {
@@ -203,8 +199,7 @@ function api_sidebar()
 /**
  * Output functions.
  */
-function api_output($arr, $last_mod = NULL)
-{
+function api_output($arr, $last_mod = NULL) {
     $output = get_http_var('output');
     if (!get_http_var('docs')) {
         $cond = api_header($output, $last_mod);
@@ -234,8 +229,7 @@ function api_output($arr, $last_mod = NULL)
 /**
  *
  */
-function api_header($o, $last_mod = NULL)
-{
+function api_header($o, $last_mod = NULL) {
     if ($last_mod && array_key_exists('HTTP_IF_MODIFIED_SINCE', $_SERVER)) {
         $t = cond_parse_http_date($_SERVER['HTTP_IF_MODIFIED_SINCE']);
         if (isset($t) && $t >= $last_mod) {
@@ -264,16 +258,14 @@ function api_header($o, $last_mod = NULL)
 /**
  *
  */
-function api_error($e)
-{
+function api_error($e) {
     api_output(['error' => $e]);
 }
 
 /**
  *
  */
-function api_output_php($arr)
-{
+function api_output_php($arr) {
     $out = serialize($arr);
     if (get_http_var('verbose')) {
         $out = str_replace(';', ";\n", $out);
@@ -284,9 +276,9 @@ function api_output_php($arr)
 /**
  *
  */
-function api_output_rabx($arr)
-{
+function api_output_rabx($arr) {
     $out = '';
+    // rabx_wire_wr is in phplib/rabx.php. It converts a PHP array into a binary format that can be read by rabx_read in the same library.
     rabx_wire_wr($arr, $out);
     if (get_http_var('verbose')) {
         $out = str_replace(',', ",\n", $out);
@@ -299,8 +291,7 @@ $api_xml_arr = 0;
 /**
  *
  */
-function api_output_xml($v, $k = NULL)
-{
+function api_output_xml($v, $k = NULL) {
     global $api_xml_arr;
     $verbose = get_http_var('verbose') ? "\n" : '';
     if (is_array($v)) {
@@ -327,8 +318,7 @@ function api_output_xml($v, $k = NULL)
 /**
  *
  */
-function api_output_js($v, $level = 0)
-{
+function api_output_js($v, $level = 0) {
     $verbose = get_http_var('verbose') ? "\n" : '';
     if (is_array($v)) {
         // PHP arrays are both JS arrays and objects.
@@ -360,7 +350,7 @@ function api_output_js($v, $level = 0)
     } elseif (is_string($v)) {
         return '"' . str_replace(
             ["\\", '"', "\n", "\t", "\r"],
-            ["\\\\", '\"', '\n', '\t', '\r'],
+            ["\\\\", '\\"', '\\n', '\\t', '\\r'],
             $v
         ) . '"';
     } elseif (is_bool($v)) {
@@ -373,8 +363,7 @@ function api_output_js($v, $level = 0)
 /**
  * Call an API function.
  */
-function api_call_user_func_or_error($function, $params, $error, $type)
-{
+function api_call_user_func_or_error($function, $params, $error, $type) {
     if (function_exists($function)) {
         call_user_func_array($function, $params);
     } elseif ($type == 'api') {
@@ -413,8 +402,7 @@ $cond_time_re = '([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|6[012])';
 /**
  *
  */
-function cond_parse_http_date($date)
-{
+function cond_parse_http_date($date) {
     $H = $M = $S = 0;
     $Y = $m = $d = 0;
 

--- a/www/docs/api/api_getBoundary.php
+++ b/www/docs/api/api_getBoundary.php
@@ -59,8 +59,7 @@ function api_getBoundary_name($name) {
     $out = mapit_get_voting_area_geometry($id, 'wgs84');
     if (isset($out['polygon'])) {
         api_output($out['polygon']);
-    }
-    else {
+    } else {
         api_error('Nothing returned from get_voting_areas_geometry');
     }
 }

--- a/www/docs/api/api_getCommittee.php
+++ b/www/docs/api/api_getCommittee.php
@@ -7,8 +7,7 @@
 /**
  *
  */
-function api_getCommittee_front()
-{
+function api_getCommittee_front() {
     ?>
     <p><big>Fetch the members of a Select Committee.</big></p>
 
@@ -55,8 +54,7 @@ function api_getCommittee_front()
 /**
  *
  */
-function api_getCommittee_name($name)
-{
+function api_getCommittee_name($name) {
     $db = new ParlDB();
 
     // Names in the database have & as &amp;...
@@ -113,7 +111,6 @@ function api_getCommittee_name($name)
 /**
  *
  */
-function api_getCommittee_date($date)
-{
+function api_getCommittee_date($date) {
     api_error('You need to give a name!');
 }

--- a/www/docs/api/api_getConstituencies.php
+++ b/www/docs/api/api_getConstituencies.php
@@ -74,8 +74,7 @@ function _api_getConstituencies_search($s) {
 function api_getConstituencies_date($date) {
     if ($date = parse_date($date)) {
         api_getConstituencies('"' . $date['iso'] . '"');
-    }
-    else {
+    } else {
         api_error('Invalid date format');
     }
 }

--- a/www/docs/api/api_getConstituency.php
+++ b/www/docs/api/api_getConstituency.php
@@ -34,16 +34,13 @@ function api_getconstituency_postcode($pc) {
         $constituency = postcode_to_constituency($pc);
         if ($constituency == 'CONNECTION_TIMED_OUT') {
             api_error('Connection timed out');
-        }
-        elseif ($constituency) {
+        } elseif ($constituency) {
             $output['name'] = html_entity_decode($constituency);
             api_output($output);
-        }
-        else {
+        } else {
             api_error('Unknown postcode');
         }
-    }
-    else {
+    } else {
         api_error('Invalid postcode');
     }
 }

--- a/www/docs/api/api_getDebates.php
+++ b/www/docs/api/api_getDebates.php
@@ -83,19 +83,16 @@ function api_getDebates_type($t) {
     if ($t == 'representatives') {
         $list = 'DEBATE';
         $type = 'debates';
-    }
-    elseif ($t == 'senate') {
+    } elseif ($t == 'senate') {
         $list = 'LORDSDEBATE';
         $type = 'lords';
-    }
-    else {
+    } else {
         api_error('Unknown type');
         return;
     }
     if ($d = get_http_var('date')) {
         _api_getHansard_date($list, $d);
-    }
-    elseif (get_http_var('search') || get_http_var('person')) {
+    } elseif (get_http_var('search') || get_http_var('person')) {
         $s = get_http_var('search');
         $pid = get_http_var('person');
         _api_getHansard_search([
@@ -103,8 +100,7 @@ function api_getDebates_type($t) {
             'pid' => $pid,
             'type' => $type,
         ]);
-    }
-    elseif ($gid = get_http_var('gid')) {
+    } elseif ($gid = get_http_var('gid')) {
         $redirect = _api_getHansard_gid($list, $gid);
         if (is_string($redirect)) {
             $URL = $_SERVER['REQUEST_URI'];
@@ -112,11 +108,9 @@ function api_getDebates_type($t) {
             // header('Location: http://' . DOMAIN . $URL);
             // exit;.
         }
-    }
-    elseif ($y = get_http_var('year')) {
+    } elseif ($y = get_http_var('year')) {
         _api_getHansard_year($list, $y);
-    }
-    else {
+    } else {
         api_error('That is not a valid search.');
     }
 }

--- a/www/docs/api/api_getDivisions.php
+++ b/www/docs/api/api_getDivisions.php
@@ -23,23 +23,19 @@ function api_getDivisions_postcode($pc) {
         $constituency = postcode_to_constituency($pc);
         if ($constituency == 'CONNECTION_TIMED_OUT') {
             api_error('Connection timed out');
-        }
-        elseif ($constituency) {
+        } elseif ($constituency) {
             if (is_array($constituency)) {
                 $constituencies = $constituency;
-            }
-            else {
+            } else {
                 $constituencies = [$constituency];
             }
             foreach ($constituencies as $c) {
                 $output[] = ['name' => html_entity_decode($c)];
             }
-        }
-        else {
+        } else {
             api_error('Unknown postcode');
         }
-    }
-    else {
+    } else {
         api_error('Invalid postcode');
     }
     api_output($output);

--- a/www/docs/api/api_getGeometry.php
+++ b/www/docs/api/api_getGeometry.php
@@ -56,8 +56,7 @@ function api_getGeometry_name($name) {
     $out = _api_getGeometry_name($name);
     if ($out) {
         api_output($out);
-    }
-    else {
+    } else {
         api_error('Name not recognised');
     }
 }

--- a/www/docs/api/api_getLord.php
+++ b/www/docs/api/api_getLord.php
@@ -7,8 +7,7 @@
 /**
  *
  */
-function api_getLord_front()
-{
+function api_getLord_front() {
     ?>
     <p><big>Fetch a particular Senator.</big></p>
 
@@ -24,8 +23,7 @@ function api_getLord_front()
 /**
  *
  */
-function _api_getLord_row($row)
-{
+function _api_getLord_row($row) {
     global $parties;
     $row['full_name'] = member_full_name(
         $row['house'],
@@ -44,8 +42,7 @@ function _api_getLord_row($row)
 /**
  *
  */
-function api_getLord_id($id)
-{
+function api_getLord_id($id) {
     $db = new ParlDB();
     $q = $db->query("select * from member
 		where house=2 and person_id = '" . $db->escape($id) . "'

--- a/www/docs/api/api_getMPInfo.php
+++ b/www/docs/api/api_getMPInfo.php
@@ -75,8 +75,7 @@ function api_getMPinfo_id($id) {
         }
         ksort($output);
         api_output($output, $last_mod);
-    }
-    else {
+    } else {
         api_error('Unknown person ID');
     }
 }

--- a/www/docs/api/api_getMembers.php
+++ b/www/docs/api/api_getMembers.php
@@ -9,8 +9,7 @@ include_once 'api_getMP.php';
 /**
  * Shared API functions for get<Members>
  */
-function _api_getMembers_output($sql)
-{
+function _api_getMembers_output($sql) {
     $db = new ParlDB();
     $q = $db->query($sql);
     $output = [];
@@ -29,9 +28,9 @@ function _api_getMembers_output($sql)
 /**
  *
  */
-function api_getMembers_party($house, $s)
-{
-    $db = new ParlDB(); // needed to call db->escape()
+function api_getMembers_party($house, $s) {
+    // Needed to call db->escape()
+    $db = new ParlDB();
     global $parties;
     $canon_to_short = array_flip($parties);
     if (isset($canon_to_short[ucwords($s)])) {
@@ -46,9 +45,9 @@ function api_getMembers_party($house, $s)
 /**
  *
  */
-function api_getMembers_state($house, $s)
-{
-    $db = new ParlDB(); // needed to call db->escape()
+function api_getMembers_state($house, $s) {
+    // Needed to call db->escape()
+    $db = new ParlDB();
     global $parties;
     $canon_to_short = array_flip($parties);
     if (isset($canon_to_short[ucwords($s)])) {
@@ -63,9 +62,9 @@ function api_getMembers_state($house, $s)
 /**
  *
  */
-function api_getMembers_search($house, $s)
-{
-    $db = new ParlDB(); // needed to call db->escape()
+function api_getMembers_search($house, $s) {
+    // Needed to call db->escape()
+    $db = new ParlDB();
     $sq = $db->escape($s);
     _api_getMembers_output('select * from member
 		where house = ' . $db->escape($house) . "
@@ -79,8 +78,7 @@ function api_getMembers_search($house, $s)
 /**
  *
  */
-function api_getMembers_date($house, $date)
-{
+function api_getMembers_date($house, $date) {
     if ($date = parse_date($date)) {
         api_getMembers($house, '"' . $date['iso'] . '"');
     } else {
@@ -91,9 +89,9 @@ function api_getMembers_date($house, $date)
 /**
  *
  */
-function api_getMembers($house, $date = 'now()')
-{
-    $db = new ParlDB(); // needed to call db->escape()
+function api_getMembers($house, $date = 'now()') {
+    // Needed to call db->escape()
+    $db = new ParlDB();
     _api_getMembers_output('select * from member where house=' . $db->escape($house) .
         ' AND entered_house <= date(' . $date . ') and date(' . $date . ') <= left_house');
 }

--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -14,8 +14,7 @@ include_once 'api_functions.php';
 if ($q_method = get_http_var('method')) {
     if (get_http_var('docs')) {
         $key = 'DOCS';
-    }
-    else {
+    } else {
         if (!get_http_var('key')) {
             api_error('No API key provided. Please see http://www.openaustralia.org/api/key for more information.');
             exit;
@@ -49,8 +48,7 @@ if ($q_method = get_http_var('method')) {
                         htmlspecialchars($q_method) .
                         '". Possible choices are: ' .
                         implode(', ', $data['parameters']));
-                }
-                else {
+                } else {
                     include_once 'api_' . $method . '.php';
                     api_call_user_func_or_error('api_' . $method, [], 'API call not yet functional', 'api');
                     break;
@@ -64,15 +62,13 @@ if ($q_method = get_http_var('method')) {
         api_front_page('Unknown function "' . htmlspecialchars($q_method) .
             '". Possible functions are: ' .
            implode(', ', array_keys($methods)));
-    }
-    else {
+    } else {
         if (get_http_var('docs')) {
             $explorer = ob_get_clean();
             api_documentation_front($method, $explorer);
         }
     }
-}
-else {
+} else {
     api_front_page();
 }
 

--- a/www/docs/api/key.php
+++ b/www/docs/api/key.php
@@ -72,8 +72,7 @@ $PAGE->page_end();
 /**
  * ---
  */
-function create_key($commercial, $reason)
-{
+function create_key($commercial, $reason) {
     global $THEUSER;
     $key = auth_ab64_encode(urandom_bytes(16));
     $db = new ParlDB();
@@ -86,8 +85,7 @@ function create_key($commercial, $reason)
 /**
  *
  */
-function api_key_form()
-{
+function api_key_form() {
     ?>
     <br>
     <h3>Apply for a new key</h3>

--- a/www/docs/debate/index.php
+++ b/www/docs/debate/index.php
@@ -61,9 +61,7 @@ if (get_http_var('id') != '') {
     }
 
 
-
-}
-else {
+} else {
     $PAGE->error_message("We need a gid");
 }
 

--- a/www/docs/debates/index.php
+++ b/www/docs/debates/index.php
@@ -20,8 +20,7 @@ if (get_http_var("d") != "") {
         ];
         $LIST = new DEBATELIST();
         $LIST->display('column', $args);
-    }
-    else {
+    } else {
         // We have a date. so show all debates on this day.
 
         $this_page = "debatesday";
@@ -35,8 +34,7 @@ if (get_http_var("d") != "") {
         $LIST->display('date', $args);
     }
 
-}
-elseif (get_http_var('id') != "") {
+} elseif (get_http_var('id') != "") {
     // We have an id so show that item.
     // Could be a section id (so we get a list of all the subsections in it),
     // or a subsection id (so we'd get the whole debate),
@@ -61,8 +59,7 @@ elseif (get_http_var('id') != "") {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -80,7 +77,6 @@ elseif (get_http_var('id') != "") {
     }
 
 
-
     // We show trackbacks on this page.
 
     $args = [
@@ -92,9 +88,7 @@ elseif (get_http_var('id') != "") {
     // $TRACKBACK->display('epobject_id', $args);
 
 
-
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     // Show a calendar for a particular year's debates.
 
@@ -127,8 +121,7 @@ elseif (get_http_var('y') != '') {
         ]
     ]);
 
-}
-else {
+} else {
     // No date or debate id. Show recent years with debates on.
 
     $this_page = "debatesfront";

--- a/www/docs/debates/mobile.php
+++ b/www/docs/debates/mobile.php
@@ -23,8 +23,7 @@ if (get_http_var("d") != "") {
         $LIST = new DEBATELIST();
         $args['mobile'] = 1;
         $LIST->display('column', $args);
-    }
-    else {
+    } else {
         // We have a date. so show all debates on this day.
 
         $this_page = "debatesday";
@@ -39,8 +38,7 @@ if (get_http_var("d") != "") {
         $LIST->display('date', $args);
     }
 
-}
-elseif (get_http_var('id') != "") {
+} elseif (get_http_var('id') != "") {
     // We have an id so show that item.
     // Could be a section id (so we get a list of all the subsections in it),
     // or a subsection id (so we'd get the whole debate),
@@ -65,8 +63,7 @@ elseif (get_http_var('id') != "") {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -85,7 +82,6 @@ elseif (get_http_var('id') != "") {
     }
 
 
-
     // We show trackbacks on this page.
 
     $args = [
@@ -97,9 +93,7 @@ elseif (get_http_var('id') != "") {
     // $TRACKBACK->display('epobject_id', $args);
 
 
-
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     // Show a calendar for a particular year's debates.
 
@@ -135,8 +129,7 @@ elseif (get_http_var('y') != '') {
     ));
      */
 
-}
-else {
+} else {
     // No date or debate id. Show recent years with debates on.
 
     $this_page = "debatesfront";

--- a/www/docs/departments/questions.php
+++ b/www/docs/departments/questions.php
@@ -11,8 +11,7 @@ $PAGE->page_start();
 $PAGE->stripe_start();
 $db = new ParlDB();
 
-if (!$dept) {
-} else {
+if ($dept) {
     $dept = strtolower(str_replace('_', ' ', $dept));
     $q = $db->query('select epobject.epobject_id from hansard,epobject
 		where hansard.epobject_id=epobject.epobject_id and major=3 and section_id=0

--- a/www/docs/departments/statements.php
+++ b/www/docs/departments/statements.php
@@ -11,8 +11,7 @@ $PAGE->page_start();
 $PAGE->stripe_start();
 $db = new ParlDB();
 
-if (!$dept) {
-} else {
+if ($dept) {
     $dept = strtolower(str_replace('_', ' ', $dept));
     $q = $db->query('select epobject.epobject_id from hansard,epobject
 		where hansard.epobject_id=epobject.epobject_id and major=4 and section_id=0

--- a/www/docs/email/index.php
+++ b/www/docs/email/index.php
@@ -56,13 +56,11 @@ if (sizeof($errors)) {
         </p>
     </form>
     <?php
-}
-else {
+} else {
     $rep_name = $MEMBER->full_name();
     if ($MEMBER->house_disp == 1) {
         $rep_name .= ' MP';
-    }
-    elseif ($MEMBER->house_disp == 3) {
+    } elseif ($MEMBER->house_disp == 3) {
         $rep_name .= ' MLA';
     }
     $data = [
@@ -81,8 +79,7 @@ else {
     $success = send_template_email($data, $merge);
     if ($success) {
         print "<p>Your email has been sent successfully. Thank you for using OpenAustralia.</p> <p><a href=\"$url\">Return to " . $MEMBER->full_name() . "'s page</a></p>";
-    }
-    else {
+    } else {
         print "<p>Sorry, something went wrong trying to send an email. Please wait a few minutes and try again.</p>";
     }
 }

--- a/www/docs/gadget/dat.php
+++ b/www/docs/gadget/dat.php
@@ -104,8 +104,7 @@ function display_dream_comparison($id, $text, $inverse = FALSE) {
     $score = $output[$id];
     if ($score == -1) {
         $pw .= '<li>Has never voted on';
-    }
-    else {
+    } else {
         if ($inverse) {
             $score = 1 - $score;
         }
@@ -135,23 +134,17 @@ function score_to_strongly($dmpscore) {
     $dmpdesc = "unknown about";
     if ($dmpscore > 0.95 && $dmpscore <= 1.0) {
         $dmpdesc = "consistently against";
-    }
-    elseif ($dmpscore > 0.85) {
+    } elseif ($dmpscore > 0.85) {
         $dmpdesc = "almost always against";
-    }
-    elseif ($dmpscore > 0.6) {
+    } elseif ($dmpscore > 0.6) {
         $dmpdesc = "generally against";
-    }
-    elseif ($dmpscore > 0.4) {
+    } elseif ($dmpscore > 0.4) {
         $dmpdesc = "a mixture of for and against";
-    }
-    elseif ($dmpscore > 0.15) {
+    } elseif ($dmpscore > 0.15) {
         $dmpdesc = "generally for";
-    }
-    elseif ($dmpscore > 0.05) {
+    } elseif ($dmpscore > 0.05) {
         $dmpdesc = "almost always for";
-    }
-    elseif ($dmpscore >= 0.0) {
+    } elseif ($dmpscore >= 0.0) {
         $dmpdesc = "consistently for";
     }
     return $dmpdesc;

--- a/www/docs/gadget/pc.php
+++ b/www/docs/gadget/pc.php
@@ -13,16 +13,13 @@ if (validate_postcode($pc)) {
     $constituency = postcode_to_constituency($pc);
     if ($constituency == 'CONNECTION_TIMED_OUT') {
         error('Connection timed out');
-    }
-    elseif ($constituency) {
+    } elseif ($constituency) {
         $pid = get_person_id($constituency);
         echo 'pid,', $pid;
-    }
-    else {
+    } else {
         error('Unknown postcode');
     }
-}
-else {
+} else {
     error('Invalid postcode');
 }
 

--- a/www/docs/glossary/index.php
+++ b/www/docs/glossary/index.php
@@ -6,8 +6,7 @@
 
 if ($term) {
     $this_page = 'glossary_item';
-}
-else {
+} else {
     $this_page = "glossary";
 }
 
@@ -46,20 +45,17 @@ if ((get_http_var('az') != '') && is_string(get_http_var('az'))) {
 if (isset($az) && array_key_exists($az, $GLOSSARY->alphabet)) {
     $GLOSSARY->current_letter = $az;
     // Otherwise make it the first letter of the current term.
-}
-elseif (isset($term)) {
+} elseif (isset($term)) {
     $GLOSSARY->current_letter = strtoupper($term['title'][0]);
     // Otherwise make it "A" by default.
-}
-else {
+} else {
     $GLOSSARY->current_letter = "A";
 }
 
 if ($term) {
     $DATA->set_page_metadata($this_page, 'title', $term['title'] . ': Glossary item');
     $DATA->set_page_metadata($this_page, 'heading', $term['title']);
-}
-else {
+} else {
     $DATA->set_page_metadata($this_page, 'title', $GLOSSARY->current_letter . ': Glossary index');
     $DATA->set_page_metadata($this_page, 'heading', 'Glossary index');
 }
@@ -109,8 +105,7 @@ if ($GLOSSARY->glossary_id != '') {
 
     $PAGE->glossary_display_term($GLOSSARY);
 
-}
-else {
+} else {
 
 
     // Display the results.

--- a/www/docs/hansard/index.php
+++ b/www/docs/hansard/index.php
@@ -53,11 +53,9 @@ if (($date = get_http_var('d')) && preg_match('#^\d\d\d\d-\d\d-\d\d$#', $date)) 
     $recess = recess_prettify(date('j', $time), date('n', $time), date('Y', $time), 1);
     if ($recess[0]) {
         print '<p>The Houses of Parliament are in ' . $recess[0] . ' at this time.</p>';
-    }
-    elseif ($dayofweek == 0 || $dayofweek == 6) {
+    } elseif ($dayofweek == 0 || $dayofweek == 6) {
         print '<p>The Houses of Parliament do not meet at weekends.</p>';
-    }
-    else {
+    } else {
         $data = [
             'date' => $date
         ];

--- a/www/docs/mlas/index.php
+++ b/www/docs/mlas/index.php
@@ -13,8 +13,7 @@ if (get_http_var('f') != 'csv') {
     $PAGE->page_start();
     $PAGE->stripe_start();
     $format = 'html';
-}
-else {
+} else {
     $format = 'csv';
 }
 
@@ -22,20 +21,15 @@ $args = [];
 
 if (get_http_var('o') == 'f') {
     $args['order'] = 'first_name';
-}
-elseif (get_http_var('o') == 'l') {
+} elseif (get_http_var('o') == 'l') {
     $args['order'] = 'last_name';
-}
-elseif (get_http_var('o') == 'c') {
+} elseif (get_http_var('o') == 'c') {
     $args['order'] = 'constituency';
-}
-elseif (get_http_var('o') == 'p') {
+} elseif (get_http_var('o') == 'p') {
     $args['order'] = 'party';
-}
-elseif (get_http_var('o') == 'e') {
+} elseif (get_http_var('o') == 'e') {
     $args['order'] = 'expenses';
-}
-elseif (get_http_var('o') == 'd') {
+} elseif (get_http_var('o') == 'd') {
     $args['order'] = 'debates';
 }
 

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -245,8 +245,6 @@ if (is_numeric(get_http_var('m'))) {
 }
 
 
-
-
 //
 // DISPLAY A REPRESENTATIVE.
 
@@ -462,8 +460,7 @@ $PAGE->page_end();
 /**
  *
  */
-function member_redirect(&$MEMBER)
-{
+function member_redirect(&$MEMBER) {
     global $this_page;
     // We come here after creating a MEMBER object by various methods.
     // Now we redirect to the canonical MP page, with a person_id.

--- a/www/docs/mp/mobile.php
+++ b/www/docs/mp/mobile.php
@@ -116,23 +116,17 @@ if (get_http_var('recent')) {
 
 if (get_http_var('c4')) {
     $this_page = 'c4_mp';
-}
-elseif (get_http_var('c4x')) {
+} elseif (get_http_var('c4x')) {
     $this_page = 'c4x_mp';
-}
-elseif (get_http_var('peer')) {
+} elseif (get_http_var('peer')) {
     $this_page = 'peer';
-}
-elseif (get_http_var('royal')) {
+} elseif (get_http_var('royal')) {
     $this_page = 'royal';
-}
-elseif (get_http_var('mla')) {
+} elseif (get_http_var('mla')) {
     $this_page = 'mla';
-}
-elseif (get_http_var('msp')) {
+} elseif (get_http_var('msp')) {
     $this_page = 'msp';
-}
-else {
+} else {
     $this_page = 'mp';
 }
 
@@ -141,8 +135,7 @@ if (is_numeric(get_http_var('m'))) {
     $MEMBER = new MEMBER(['member_id' => get_http_var('m')]);
     member_redirect($MEMBER);
 
-}
-elseif (is_numeric($pid)) {
+} elseif (is_numeric($pid)) {
 
     // Normal, plain, displaying an MP by person ID.
     $MEMBER = new MEMBER(['person_id' => $pid]);
@@ -151,8 +144,7 @@ elseif (is_numeric($pid)) {
     //
     // CHECK SUBMITTED POSTCODE.
 
-}
-elseif (get_http_var('pc') != '') {
+} elseif (get_http_var('pc') != '') {
     // User has submitted a postcode, so we want to display that.
     $pc = get_http_var('pc');
     $pc = preg_replace('#[^a-z0-9 ]#i', '', $pc);
@@ -161,19 +153,16 @@ elseif (get_http_var('pc') != '') {
         // Only do lookup of constituency via postcode if the constituency isn't set.
         if ($cconstituency == "") {
             $constituency = postcode_to_constituency($pc);
-        }
-        else {
+        } else {
             $constituency = $cconstituency;
         }
 
         if ($constituency == "connection_timed_out") {
             $errors['pc'] = "Sorry, we couldn't check your postcode right now, as our postcode lookup server is under quite a lot of load. Please use the 'All MPs' link above to browse all the MPs.";
-        }
-        elseif ($constituency == "") {
+        } elseif ($constituency == "") {
             $errors['pc'] = "Sorry, " . htmlentities($pc) . " isn't a known postcode";
             twfy_debug('MP', "Can't display an MP, as submitted postcode didn't match a constituency");
-        }
-        elseif (is_array($constituency)) {
+        } elseif (is_array($constituency)) {
             $PAGE->page_start_mobile();
             $PAGE->stripe_start();
             print '<p>There are several electoral divisions within your postcode. Please select from the following:</p><ul>';
@@ -192,8 +181,7 @@ elseif (get_http_var('pc') != '') {
             ];
 
             // $PAGE->stripe_end(array($sidebar));
-        }
-        else {
+        } else {
             // Redirect to the canonical MP page, with a person id.
             $MEMBER = new MEMBER(['constituency' => $constituency]);
             if ($MEMBER->person_id()) {
@@ -211,16 +199,14 @@ elseif (get_http_var('pc') != '') {
                     ];
                     $success = $THEUSER->update_self($details);
                     // TODO: Check success of database update.
-                }
-                else {
+                } else {
                     // This will cookie the postcode.
                     $THEUSER->set_constituency_cookie($constituency);
                 }
             }
             member_redirect($MEMBER);
         }
-    }
-    else {
+    } else {
         $errors['pc'] = "Sorry, " . htmlentities($pc) . " isn't a valid postcode";
         twfy_debug('MP', "Can't display an MP because the submitted postcode wasn't of a valid form.");
     }
@@ -229,12 +215,10 @@ elseif (get_http_var('pc') != '') {
     // DOES THE USER HAVE A POSTCODE ALREADY SET?
     // (Either in their logged-in details or in a cookie from a previous search.)
 
-}
-elseif ($THEUSER->constituency_is_set() && $name == '' && $cconstituency == '') {
+} elseif ($THEUSER->constituency_is_set() && $name == '' && $cconstituency == '') {
     $MEMBER = new MEMBER(['constituency' => $THEUSER->constituency()]);
     member_redirect($MEMBER);
-}
-elseif ($name && $cconstituency) {
+} elseif ($name && $cconstituency) {
     $MEMBER = new MEMBER(['name' => $name, 'constituency' => $cconstituency]);
     if (!$MEMBER->canonical || $redirect) {
         member_redirect($MEMBER);
@@ -243,8 +227,7 @@ elseif ($name && $cconstituency) {
         $this_page = 'yourmp';
     }
     twfy_debug('MP', 'Displaying MP by name');
-}
-elseif ($name) {
+} elseif ($name) {
     $MEMBER = new MEMBER(['name' => $name]);
     if (
         ((($MEMBER->house_disp == 1)
@@ -253,8 +236,7 @@ elseif ($name) {
     ) {
         member_redirect($MEMBER);
     }
-}
-elseif ($cconstituency) {
+} elseif ($cconstituency) {
 
     if ($cconstituency == 'your &amp; my society') {
         header('Location: /mp/stom%20teinberg');
@@ -262,13 +244,10 @@ elseif ($cconstituency) {
     }
     $MEMBER = new MEMBER(['constituency' => $cconstituency]);
     member_redirect($MEMBER);
-}
-else {
+} else {
     // No postcode, member_id or person_id to use.
     twfy_debug('MP', "We don't have any way of telling what MP to display");
 }
-
-
 
 
 //
@@ -295,8 +274,7 @@ if (isset($MEMBER) && is_array($MEMBER->person_id())) {
 
     // $PAGE->stripe_end(array($sidebar));
 
-}
-elseif (isset($MEMBER) && $MEMBER->person_id()) {
+} elseif (isset($MEMBER) && $MEMBER->person_id()) {
 
     twfy_debug_timestamp("before load_extra_info");
     $MEMBER->load_extra_info();
@@ -306,14 +284,12 @@ elseif (isset($MEMBER) && $MEMBER->person_id()) {
 
     if ($MEMBER->current_member(2)) {
         $subtitle = "Senator " . $member_name . ', ' . $MEMBER->constituency();
-    }
-    else {
+    } else {
         $subtitle = $member_name;
         if ($MEMBER->house(1)) {
             if (!$MEMBER->current_member(1)) {
                 $subtitle .= ', former Representative';
-            }
-            else {
+            } else {
                 $subtitle .= ' MP';
             }
             $subtitle .= ', ' . $MEMBER->constituency();
@@ -474,8 +450,7 @@ keeping these sorts of records on you...</p></div></div>'
     ];
     // $PAGE->stripe_end($sidebars);
 
-}
-else {
+} else {
     // Something went wrong.
 
     //

--- a/www/docs/mps/index.php
+++ b/www/docs/mps/index.php
@@ -10,8 +10,7 @@ include_once INCLUDESPATH . "easyparliament/people.php";
 $this_page = 'mps';
 if (get_http_var('c4')) {
     $this_page = 'c4_mps';
-}
-elseif (get_http_var('c4x')) {
+} elseif (get_http_var('c4x')) {
     $this_page = 'c4x_mps';
 }
 
@@ -19,8 +18,7 @@ if (get_http_var('f') != 'csv') {
     $PAGE->page_start();
     $PAGE->stripe_start();
     $format = 'html';
-}
-else {
+} else {
     $format = 'csv';
 }
 
@@ -28,23 +26,17 @@ $args = [];
 
 if (get_http_var('o') == 'f') {
     $args['order'] = 'first_name';
-}
-elseif (get_http_var('o') == 'l') {
+} elseif (get_http_var('o') == 'l') {
     $args['order'] = 'last_name';
-}
-elseif (get_http_var('o') == 'c') {
+} elseif (get_http_var('o') == 'c') {
     $args['order'] = 'constituency';
-}
-elseif (get_http_var('o') == 'p') {
+} elseif (get_http_var('o') == 'p') {
     $args['order'] = 'party';
-}
-elseif (get_http_var('o') == 'e') {
+} elseif (get_http_var('o') == 'e') {
     $args['order'] = 'expenses';
-}
-elseif (get_http_var('o') == 'd') {
+} elseif (get_http_var('o') == 'd') {
     $args['order'] = 'debates';
-}
-elseif (get_http_var('o') == 's') {
+} elseif (get_http_var('o') == 's') {
     $args['order'] = 'safety';
 }
 

--- a/www/docs/msps/index.php
+++ b/www/docs/msps/index.php
@@ -13,8 +13,7 @@ if (get_http_var('f') != 'csv') {
     $PAGE->page_start();
     $PAGE->stripe_start();
     $format = 'html';
-}
-else {
+} else {
     $format = 'csv';
 }
 
@@ -22,20 +21,15 @@ $args = [];
 
 if (get_http_var('o') == 'f') {
     $args['order'] = 'first_name';
-}
-elseif (get_http_var('o') == 'l') {
+} elseif (get_http_var('o') == 'l') {
     $args['order'] = 'last_name';
-}
-elseif (get_http_var('o') == 'c') {
+} elseif (get_http_var('o') == 'c') {
     $args['order'] = 'constituency';
-}
-elseif (get_http_var('o') == 'p') {
+} elseif (get_http_var('o') == 'p') {
     $args['order'] = 'party';
-}
-elseif (get_http_var('o') == 'e') {
+} elseif (get_http_var('o') == 'e') {
     $args['order'] = 'expenses';
-}
-elseif (get_http_var('o') == 'd') {
+} elseif (get_http_var('o') == 'd') {
     $args['order'] = 'debates';
 }
 

--- a/www/docs/news/index.php
+++ b/www/docs/news/index.php
@@ -34,8 +34,7 @@ if (preg_match("#/(\d\d\d\d)/(\d\d)/(\d\d)/([a-z0-9_]+)(\.php)?$#", $uri, $match
         print " | <a href=\"" . news_individual_link($date, $title) . "\">Link to this</a>";
         break;
     }
-}
-elseif (preg_match("#/(\d\d\d\d)/(\d\d)/?(index.php)?$#", $uri, $matches)) {
+} elseif (preg_match("#/(\d\d\d\d)/(\d\d)/?(index.php)?$#", $uri, $matches)) {
     // Month index.
     [$all, $year, $month] = $matches;
     $this_page = 'sitenews_date';
@@ -56,8 +55,7 @@ elseif (preg_match("#/(\d\d\d\d)/(\d\d)/?(index.php)?$#", $uri, $matches)) {
         }
         print " | <a href=\"" . news_individual_link($date, $title) . "\">Link to this</a>";
     }
-}
-else {
+} else {
     // Front page /news.
     $this_page = 'sitenews';
     $PAGE->page_start();

--- a/www/docs/ni/index.php
+++ b/www/docs/ni/index.php
@@ -17,8 +17,7 @@ if (get_http_var("d") != "") {
     $LIST = new NILIST();
     $LIST->display('date', $args);
 
-}
-elseif (get_http_var('id') != "") {
+} elseif (get_http_var('id') != "") {
     $this_page = "nidebates";
     $args = [
         'gid' => get_http_var('id'),
@@ -37,8 +36,7 @@ elseif (get_http_var('id') != "") {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -54,8 +52,7 @@ elseif (get_http_var('id') != "") {
         exit;
     }
 
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     $this_page = 'nidebatesyear';
 
@@ -86,8 +83,7 @@ elseif (get_http_var('y') != '') {
         ]
     ]);
 
-}
-elseif (get_http_var('gid') != '') {
+} elseif (get_http_var('gid') != '') {
     $this_page = 'nidebate';
     $args = ['gid' => get_http_var('gid')];
     $NILIST = new NILIST();
@@ -107,8 +103,7 @@ elseif (get_http_var('gid') != '') {
         $COMMENTLIST->display('ep', $args);
         $PAGE->stripe_end();
     }
-}
-else {
+} else {
     $this_page = "nidebatesfront";
     $PAGE->page_start();
     $PAGE->stripe_start();

--- a/www/docs/parsing/index.php
+++ b/www/docs/parsing/index.php
@@ -45,8 +45,7 @@ $notloaded = '';
                 if ($date > '2001-05-11') {
                     $out[$date] = "<li>$date : $part version $version, size $stat[7] bytes, last modified " . date('Y-m-d H:i:s', $stat[9]) . "</li>\n";
                 }
-            }
-            else {
+            } else {
                 if (!array_key_exists($date, $hdates) || !array_key_exists($majors[$k], $hdates[$date])) {
                     $notloaded .= "<li>$date : $part version $version</li>\n";
                 }

--- a/www/docs/pbc/index.php
+++ b/www/docs/pbc/index.php
@@ -35,8 +35,7 @@ if ($bill_id && !$id) {
         'session' => $session,
     ];
     $committee->display('bill', $args);
-}
-elseif ($bill_id && $id) {
+} elseif ($bill_id && $id) {
     $this_page = 'pbc_clause';
     $args = [
         'gid' => $standingprefix . $id,
@@ -65,16 +64,14 @@ elseif ($bill_id && $id) {
         $COMMENTLIST->display('ep', $args);
         $PAGE->stripe_end();
     }
-}
-elseif ($session) {
+} elseif ($session) {
     $this_page = 'pbc_session';
     $DATA->set_page_metadata($this_page, 'title', "Session $session");
     $args = [
         'session' => $session,
     ];
     $committee->display('session', $args);
-}
-else {
+} else {
     $this_page = "pbc_front";
     $PAGE->page_start();
     $PAGE->stripe_start();

--- a/www/docs/regmem/index.php
+++ b/www/docs/regmem/index.php
@@ -76,14 +76,11 @@ if (!preg_match('#^\d\d\d\d-\d\d-\d\d$#', $d)) {
 $link = '<p align="center"><a href="./"><strong>List all MPs and Register editions</strong></a></p>';
 if ($f) {
     register_history($f);
-}
-elseif ($p) {
+} elseif ($p) {
     person_history($p);
-}
-elseif ($d) {
+} elseif ($d) {
     show_register($d);
-}
-else {
+} else {
     $this_page = 'regmem';
     $PAGE->stripe_start();
     front_page();
@@ -248,8 +245,7 @@ function by_name_ref($a, $b) {
     $b = preg_replace('/^.* /', '', $names[$b]);
     if ($a > $b) {
         return 1;
-    }
-    elseif ($a < $b) {
+    } elseif ($a < $b) {
         return -1;
     }
     return 0;
@@ -410,8 +406,7 @@ function by_name($a, $b) {
     $b = preg_replace('/^.* /', '', $b);
     if ($a > $b) {
         return 1;
-    }
-    elseif ($a < $b) {
+    } elseif ($a < $b) {
         return -1;
     }
     return 0;

--- a/www/docs/rss/index.php
+++ b/www/docs/rss/index.php
@@ -18,12 +18,10 @@ if (validate_postcode($pc)) {
     $constituency = strtolower(postcode_to_constituency($pc));
     if ($constituency == "CONNECTION_TIMED_OUT") {
         $errors['pc'] = "Sorry, we couldn't check your postcode right now. Please use the 'All Mps' link above to browse MPs";
-    }
-    elseif ($constituency == "") {
+    } elseif ($constituency == "") {
         $errors['pc'] = "Sorry, " . htmlentities($pc) . " isn't a known postcode";
         twfy_debug('MP', "Can't display an MP, as submitted postcode didn't match a constituency");
-    }
-    else {
+    } else {
         $MEMBER = new MEMBER(['constituency' => $constituency]);
         if ($MEMBER->person_id()) {
             // This will cookie the postcode.
@@ -35,8 +33,7 @@ if (validate_postcode($pc)) {
             header('Location: http://' . DOMAIN . '/rss/mp/' . $MEMBER->person_id() . '.rdf');
         }
     }
-}
-else {
+} else {
     $errors['pc'] = "Sorry, " . htmlentities($pc) . " isn't a valid postcode";
     twfy_debug('MP', "Can't display an MP because the submitted postcode wasn't of a valid form.");
 }

--- a/www/docs/senate/index.php
+++ b/www/docs/senate/index.php
@@ -18,8 +18,7 @@ if (get_http_var("d") != "") {
         ];
         $LIST = new LORDSDEBATELIST();
         $LIST->display('column', $args);
-    }
-    else {
+    } else {
         // We have a date. so show all debates on this day.
 
         $this_page = "lordsdebatesday";
@@ -33,8 +32,7 @@ if (get_http_var("d") != "") {
         $LIST->display('date', $args);
     }
 
-}
-elseif (get_http_var('id') != "") {
+} elseif (get_http_var('id') != "") {
     // We have an id so show that item.
     // Could be a section id (so we get a list of all the subsections in it),
     // or a subsection id (so we'd get the whole debate),
@@ -59,8 +57,7 @@ elseif (get_http_var('id') != "") {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -83,8 +80,7 @@ elseif (get_http_var('id') != "") {
     // $TRACKBACK = new TRACKBACK;
     // $TRACKBACK->display('epobject_id', $args);.
 
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     // Show a calendar for a particular year's debates.
 
@@ -118,8 +114,7 @@ elseif (get_http_var('y') != '') {
         ]
     ]);
 
-}
-elseif (get_http_var('gid') != '') {
+} elseif (get_http_var('gid') != '') {
     $this_page = 'lordsdebate';
     $args = ['gid' => get_http_var('gid')];
     $LORDSDEBATELIST = new LORDSDEBATELIST();
@@ -141,8 +136,7 @@ elseif (get_http_var('gid') != '') {
         // $TRACKBACK = new TRACKBACK;
         // $TRACKBACK->display('epobject_id', $commendata);
     }
-}
-else {
+} else {
     // No date or debate id. Show recent years with debates on.
 
     $this_page = "lordsdebatesfront";

--- a/www/docs/senate/mobile.php
+++ b/www/docs/senate/mobile.php
@@ -21,8 +21,7 @@ if (get_http_var("d") != "") {
         $LIST = new LORDSDEBATELIST();
         $args['mobile'] = 1;
         $LIST->display('column', $args);
-    }
-    else {
+    } else {
         // We have a date. so show all debates on this day.
 
         $this_page = "lordsdebatesday";
@@ -37,8 +36,7 @@ if (get_http_var("d") != "") {
         $LIST->display('date', $args);
     }
 
-}
-elseif (get_http_var('id') != "") {
+} elseif (get_http_var('id') != "") {
     // We have an id so show that item.
     // Could be a section id (so we get a list of all the subsections in it),
     // or a subsection id (so we'd get the whole debate),
@@ -63,8 +61,7 @@ elseif (get_http_var('id') != "") {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -88,8 +85,7 @@ elseif (get_http_var('id') != "") {
     // $TRACKBACK = new TRACKBACK;
     // $TRACKBACK->display('epobject_id', $args);.
 
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     // Show a calendar for a particular year's debates.
 
@@ -125,8 +121,7 @@ elseif (get_http_var('y') != '') {
     ));
      */
 
-}
-elseif (get_http_var('gid') != '') {
+} elseif (get_http_var('gid') != '') {
     $this_page = 'lordsdebate';
     $args = ['gid' => get_http_var('gid')];
     $LORDSDEBATELIST = new LORDSDEBATELIST();
@@ -150,8 +145,7 @@ elseif (get_http_var('gid') != '') {
         // $TRACKBACK = new TRACKBACK;
         // $TRACKBACK->display('epobject_id', $commendata);
     }
-}
-else {
+} else {
     // No date or debate id. Show recent years with debates on.
 
     $this_page = "lordsdebatesfront";

--- a/www/docs/senators/index.php
+++ b/www/docs/senators/index.php
@@ -13,8 +13,7 @@ if (get_http_var('f') != 'csv') {
     $PAGE->page_start();
     $PAGE->stripe_start();
     $format = 'html';
-}
-else {
+} else {
     $format = 'csv';
 }
 
@@ -22,17 +21,13 @@ $args = ['order' => 'name'];
 
 if (get_http_var('o') == 'l' || get_http_var('o') == 'n') {
     $args['order'] = 'last_name';
-}
-elseif (get_http_var('o') == 'f') {
+} elseif (get_http_var('o') == 'f') {
     $args['order'] = 'first_name';
-}
-elseif (get_http_var('o') == 'p') {
+} elseif (get_http_var('o') == 'p') {
     $args['order'] = 'party';
-}
-elseif (get_http_var('o') == 'c') {
+} elseif (get_http_var('o') == 'c') {
     $args['order'] = 'constituency';
-}
-elseif (get_http_var('o') == 'd') {
+} elseif (get_http_var('o') == 'd') {
     $args['order'] = 'debates';
 }
 

--- a/www/docs/sp/index.php
+++ b/www/docs/sp/index.php
@@ -17,8 +17,7 @@ if (get_http_var("d") != "") {
     $LIST = new SPLIST();
     $LIST->display('date', $args);
 
-}
-elseif (get_http_var('id') != "") {
+} elseif (get_http_var('id') != "") {
     $this_page = "spdebates";
     $args = [
         'gid' => get_http_var('id'),
@@ -37,8 +36,7 @@ elseif (get_http_var('id') != "") {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -54,8 +52,7 @@ elseif (get_http_var('id') != "") {
         exit;
     }
 
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     $this_page = 'spdebatesyear';
 
@@ -86,8 +83,7 @@ elseif (get_http_var('y') != '') {
         ]
     ]);
 
-}
-elseif (get_http_var('gid') != '') {
+} elseif (get_http_var('gid') != '') {
     $this_page = 'spdebate';
     $args = ['gid' => get_http_var('gid')];
     $LIST = new SPLIST();
@@ -107,8 +103,7 @@ elseif (get_http_var('gid') != '') {
         $COMMENTLIST->display('ep', $args);
         $PAGE->stripe_end();
     }
-}
-else {
+} else {
     $this_page = "spdebatesfront";
     $PAGE->page_start();
     $PAGE->stripe_start();

--- a/www/docs/spwrans/index.php
+++ b/www/docs/spwrans/index.php
@@ -19,8 +19,7 @@ if (get_http_var('d')) {
     $LIST = new SPWRANSLIST();
     $LIST->display('date', $args);
 
-}
-elseif (get_http_var('spid')) {
+} elseif (get_http_var('spid')) {
     // We have a Scottish Parliament ID, need to find the date.
     $spid = get_http_var('spid');
     $SPWRANSLIST = new SPWRANSLIST();
@@ -33,8 +32,7 @@ elseif (get_http_var('spid')) {
     }
     $PAGE->error_message("Couldn't match that Scottish Parliament ID to a GID.");
 
-}
-elseif (get_http_var('id')) {
+} elseif (get_http_var('id')) {
     // We have an id so show that item.
     // Could be a section id or a q/a id.
     // Either way, we'll get a section heading and the q/as beneath it.
@@ -57,8 +55,7 @@ elseif (get_http_var('id')) {
     // Glossary can be turned off in the url.
     if (get_http_var('ug') == 1) {
         $args['glossarise'] = 0;
-    }
-    else {
+    } else {
         $args['sort'] = "regexp_replace";
         $GLOSSARY = new GLOSSARY($args);
     }
@@ -86,21 +83,7 @@ elseif (get_http_var('id')) {
     $COMMENTLIST->display('ep', $args);
 
     $PAGE->stripe_end();
-
-
-
-
-
-
-
-    // $TRACKBACK = new TRACKBACK;
-
-    // $TRACKBACK->display('epobject_id', $commentdata);
-
-
-
-}
-elseif (get_http_var('y') != '') {
+} elseif (get_http_var('y') != '') {
 
     // Show a calendar for a particular year's debates.
 
@@ -136,9 +119,7 @@ elseif (get_http_var('y') != '') {
     ]);
 
 
-
-}
-elseif (get_http_var('pid')) {
+} elseif (get_http_var('pid')) {
     $this_page = "spwransmp";
     $args = [
         'person_id' => get_http_var('pid'),
@@ -151,8 +132,7 @@ elseif (get_http_var('pid')) {
     }
     $LIST = new SPWRANSLIST();
     $LIST->display('mp', $args);
-}
-else {
+} else {
 
     // No date or wrans id. Show recent days with wrans on.
 

--- a/www/docs/user/confirm/index.php
+++ b/www/docs/user/confirm/index.php
@@ -45,8 +45,7 @@ if (get_http_var('welcome') == 't') {
                 href="mailto:<?php echo CONTACTEMAIL; ?>">let us know</a> if you find a bug, or have a suggestion.</p>
 
         <?php
-    }
-    else {
+    } else {
         // Oops, something must have gone wrong when the user was logged in.
         // It shouldn't do, but...
         $PAGE->error_message("Sorry, we couldn't log you in");
@@ -62,8 +61,7 @@ if (get_http_var('welcome') == 't') {
     $PAGE->page_end();
 
 
-}
-elseif (get_http_var('t') != '') {
+} elseif (get_http_var('t') != '') {
     // The user's first visit to this page, and they have a registration token.
     // So let's confirm them and hope they get logged in...
 
@@ -73,8 +71,7 @@ elseif (get_http_var('t') != '') {
         confirm_error();
     }
 
-}
-else {
+} else {
     // We have no registration token, and no notification of welcome...
 
     confirm_error();

--- a/www/docs/user/index.php
+++ b/www/docs/user/index.php
@@ -135,15 +135,13 @@ if (get_http_var("submitted") == "true") {
         if (get_http_var("deleted") != "") {
             $deleted = get_http_var("deleted");
             $details["deleted"] = $deleted[0] == "true" ? TRUE : FALSE;
-        }
-        else {
+        } else {
             $details['deleted'] = FALSE;
         }
         if (get_http_var("confirmed") != "") {
             $confirmed = get_http_var("confirmed");
             $details["confirmed"] = $confirmed[0] == "true" ? TRUE : FALSE;
-        }
-        else {
+        } else {
             $details['confirmed'] = FALSE;
         }
     }
@@ -165,14 +163,12 @@ if (get_http_var("submitted") == "true") {
 
         $PAGE->page_end();
 
-    }
-    elseif ($this_page == "userjoin") {
+    } elseif ($this_page == "userjoin") {
         // No errors so far, so try to sign up and log in.
 
         add_user($details);
 
-    }
-    else {
+    } else {
         // No errors so far, editing an existing user,
         // $this_page == "useredit" or "otheruseredit".
 
@@ -181,9 +177,7 @@ if (get_http_var("submitted") == "true") {
     }
 
 
-
-}
-else {
+} else {
     // THEUSER has just arrived at this page, no form submitted.
 
 
@@ -191,8 +185,7 @@ else {
 
         display_user();
 
-    }
-    else {
+    } else {
 
 
         $PAGE->page_start();
@@ -215,8 +208,7 @@ else {
             // Display the form with this user's info.
             display_form($details);
 
-        }
-        elseif ($this_page == "otheruseredit") {
+        } elseif ($this_page == "otheruseredit") {
 
             // We're editing the info of a different user.
             // So set up a new user object with the id supplied
@@ -243,8 +235,7 @@ else {
             // Display the form with the other user's info.
             display_form($details);
 
-        }
-        else {
+        } else {
 
             // $this_page == "userjoin".
             // Display a blank form.
@@ -286,13 +277,11 @@ function check_input($details) {
     if ($details["email"] == "") {
         $errors["email"] = "Please enter $who email address";
 
-    }
-    elseif (!validate_email($details["email"])) {
+    } elseif (!validate_email($details["email"])) {
         // validate_email() is in includes/utilities.php.
         $errors["email"] = "Please enter a valid email address";
 
-    }
-    else {
+    } else {
 
         $USER = new USER();
         $id_of_user_with_this_addresss = $USER->email_exists($details["email"]);
@@ -312,8 +301,7 @@ function check_input($details) {
                 $errors["email"] = "Someone else has already joined with this email address";
             }
 
-        }
-        else {
+        } else {
             // User is joining. Check no one is already here with this email.
             if ($this_page == "userjoin" && $id_of_user_with_this_addresss) {
                 $errors["email"] = "There is already a user with this email address";
@@ -328,8 +316,7 @@ function check_input($details) {
         if ($details["password"] == "") {
             $errors["password"] = "Please enter $who password";
 
-        }
-        elseif (strlen($details["password"]) < 6) {
+        } elseif (strlen($details["password"]) < 6) {
             $errors["password"] = "Please enter at least six characters";
         }
 
@@ -341,8 +328,7 @@ function check_input($details) {
             $errors["password"] = ucfirst($who) . " passwords did not match. Please try again.";
         }
 
-    }
-    else {
+    } else {
 
         // Update details pages.
 
@@ -444,8 +430,7 @@ function add_user($details) {
 
          */
 
-    }
-    else {
+    } else {
 
         // Something went wrong, so display the form (with error messages).
 
@@ -480,8 +465,7 @@ function update_user($details) {
         // For displaying the altered info.
         $user_id = $details["user_id"];
 
-    }
-    else {
+    } else {
         // $this_page == "useredit"
 
         $success = $THEUSER->update_self($details);
@@ -495,15 +479,13 @@ function update_user($details) {
 
         if ($this_page == 'otheruseredit') {
             $this_page = "userview";
-        }
-        else {
+        } else {
             $this_page = "userviewself";
         }
 
         display_user($user_id);
 
-    }
-    else {
+    } else {
         // Something went wrong.
 
         $PAGE->page_start();
@@ -529,8 +511,7 @@ function display_form($details = [], $errors = []) {
 
         $PAGE->error_message($errors["db"]);
 
-    }
-    else {
+    } else {
 
         $URL = new URL("userlogin");
 
@@ -685,14 +666,13 @@ function display_form($details = [], $errors = []) {
         </div>
 
 
-
         <div class="row">
-            &nbsp;<br>Do <?php if ($this_page == "otheruseredit") {
+            &nbsp;<br>Do <?php
+            if ($this_page == "otheruseredit") {
                 echo "they";
-}
-                         else {
-                             echo "you";
-                         } ?> wish to receive
+            } else {
+                echo "you";
+            } ?> wish to receive
             occasional update emails about OpenAustralia.org?
         </div>
 
@@ -800,8 +780,7 @@ function display_form($details = [], $errors = []) {
 
         if ($this_page == "useredit" || $this_page == "otheruseredit") {
             $submittext = "Update details";
-        }
-        else {
+        } else {
             $submittext = "Join OpenAustralia.org";
         }
 
@@ -857,8 +836,7 @@ function display_form($details = [], $errors = []) {
             ]
         ]);
 
-    }
-    else {
+    } else {
         $PAGE->stripe_end();
     }
 
@@ -894,26 +872,22 @@ function display_user($user_id = "") {
         $display = "this user";
         $edited = TRUE;
 
-    }
-    elseif (is_numeric($user_id)) {
+    } elseif (is_numeric($user_id)) {
         // Display someone else's just edited info.
         $display = "another user";
         $edited = TRUE;
 
-    }
-    elseif (is_numeric(get_http_var("u"))) {
+    } elseif (is_numeric(get_http_var("u"))) {
         // Display someone else's info.
         $user_id = get_http_var("u");
         $display = "another user";
 
-    }
-    elseif ($THEUSER->isloggedin()) {
+    } elseif ($THEUSER->isloggedin()) {
         // Display this user's info.
         $display = "this user";
         $user_id = $THEUSER->user_id();
 
-    }
-    else {
+    } else {
         // Nothing to show!
         $URL = new URL('userlogin');
         $URL->insert(['ret' => '/user/']);
@@ -948,14 +922,12 @@ function display_user($user_id = "") {
             // Change the page title to reflect whose info we're viewing.
             $DATA->set_page_metadata($this_page, "title", "$name");
 
-        }
-        else {
+        } else {
             // This user_id doesn't exist.
             $display = "none";
         }
 
-    }
-    elseif ($display == "this user") {
+    } elseif ($display == "this user") {
 
         // Display THEUSER's info.
         $name = $THEUSER->firstname() . " " . $THEUSER->lastname();
@@ -966,8 +938,7 @@ function display_user($user_id = "") {
             $emailpublic = $THEUSER->emailpublic() == TRUE ? "Yes" : "No";
             $optin = $THEUSER->optin() == TRUE ? "Yes" : "No";
             $constituency = $THEUSER->constituency();
-        }
-        else {
+        } else {
             // We're showing them how they're seen to other people.
             if ($THEUSER->emailpublic()) {
                 $email = $THEUSER->email();
@@ -981,8 +952,7 @@ function display_user($user_id = "") {
         // info that shouldn't be public.
         $DATA->set_page_metadata($this_page, "title", "Your details");
 
-    }
-    else {
+    } else {
 
         // There's nothing to display!
 
@@ -1034,8 +1004,7 @@ function display_user($user_id = "") {
             if (isset($email)) {
                 $escaped_email = str_replace('@', '&#64;', htmlentities($email));
                 ?><a href="mailto:<?php echo $escaped_email . "\">" . $escaped_email; ?></a><?php
-            }
-            else {
+            } else {
                 ?>Not public<?php
             }
             ?></span>
@@ -1059,8 +1028,7 @@ function display_user($user_id = "") {
         if (isset($url)) {
             if ($url == '') {
                 $url = 'none';
-            }
-            else {
+            } else {
                 $url = '<a href="' . htmlentities($url) . '">' . htmlentities($url) . '</a>';
             }
             ?>

--- a/www/docs/user/login/index.php
+++ b/www/docs/user/login/index.php
@@ -32,20 +32,18 @@ if (get_http_var("submitted") == "true") {
 
     if ($email == "") {
         $errors["email"] = "Please enter your email address";
-    }
-    elseif (!validate_email($email)) {
+    } elseif (!validate_email($email)) {
         $errors["email"] = "Please enter a valid email address";
     }
     if ($password == "") {
         $errors["password"] = "Please enter your password";
     }
 
-    if (sizeof($errors) > 0) {
+    if (count($errors) > 0) {
         // Validation errors. Print form again.
         display_page($errors);
 
-    }
-    else {
+    } else {
         // No errors so far, so try to log in.
 
         $valid = $THEUSER->isvalid($email, $password);
@@ -54,16 +52,14 @@ if (get_http_var("submitted") == "true") {
             // No validation errors.
             if ($remember == "true") {
                 $expire = "never";
-            }
-            else {
+            } else {
                 $expire = "session";
             }
 
             // $returnurl is the url of where we'll send the user after login.
             $THEUSER->login($returnurl, $expire);
 
-        }
-        else {
+        } else {
 
             // Merge the validation errors with any we already have.
             $errors = array_merge($errors, $valid);
@@ -73,8 +69,7 @@ if (get_http_var("submitted") == "true") {
 
     }
 
-}
-else {
+} else {
     // First time to the page...
     display_page();
 }

--- a/www/docs/user/password/index.php
+++ b/www/docs/user/password/index.php
@@ -34,11 +34,9 @@ if (get_http_var("submitted")) {
 
     if ($email == "") {
         $errors["email"] = "Please enter your email address";
-    }
-    elseif (!validate_email($email)) {
+    } elseif (!validate_email($email)) {
         $errors["email"] = "Please enter a valid email address";
-    }
-    else {
+    } else {
 
         $USER = new USER();
         $emailexists = $USER->email_exists($email);
@@ -48,17 +46,15 @@ if (get_http_var("submitted")) {
 
     }
 
-    if (sizeof($errors) > 0) {
+    if (count($errors) > 0) {
         // Validation errors. Print form again.
         display_page($errors);
 
-    }
-    else {
+    } else {
 
         // Change the user's password!
 
         $password = $USER->change_password($email);
-
 
 
         if ($password) {
@@ -69,8 +65,7 @@ if (get_http_var("submitted")) {
 
                 print "<p>A new password has been sent to " . htmlentities($email) . "</p>\n";
 
-            }
-            else {
+            } else {
 
                 $errors["sending"] = "Sorry, there was a technical problem sending the email.";
 
@@ -78,8 +73,7 @@ if (get_http_var("submitted")) {
 
             }
 
-        }
-        else {
+        } else {
             // This email address isn't in the DB.
 
             $errors["passwordchange"] = "Sorry, there was a problem and we couldn't set a new password for " . htmlentities($email);
@@ -91,8 +85,7 @@ if (get_http_var("submitted")) {
 
     }
 
-}
-else {
+} else {
 
     display_page();
 }
@@ -105,8 +98,7 @@ function display_page($errors = []) {
 
     if (isset($errors["sending"])) {
         $PAGE->error_message($errors["sending"]);
-    }
-    else {
+    } else {
         print "<p>If you can't remember your password we can send you a new one.</p>\n<p>If you would like a new password, enter your address below.</p>\n";
     }
     ?>

--- a/www/docs/user/prompt/index.php
+++ b/www/docs/user/prompt/index.php
@@ -32,8 +32,7 @@ if ($type == 2) {
     $glossary_returl = $URL->generate();
     $anchor = '';
 
-}
-else {
+} else {
     // Comment.
     $message = "Sorry, you must be logged in to post a comment.";
     $message2 = "You'll be able to post your comment straight after.";

--- a/www/includes/easyparliament/alert.php
+++ b/www/includes/easyparliament/alert.php
@@ -238,8 +238,7 @@ class ALERT {
             if ($deleted) {
                 $this->db->query("UPDATE alerts SET deleted=0 WHERE email='" . $this->db->escape($details['email']) . "' AND criteria='" . $this->db->escape($criteria) . "' AND confirmed=1");
                 return 1;
-            }
-            else {
+            } else {
                 return -2;
             }
         }
@@ -251,8 +250,7 @@ class ALERT {
         // MJ OA-437 add as recommendation.
         if ($details['recommended'] == 1) {
             $sql .= "'1',";
-        }
-        else {
+        } else {
             $sql .= "'0',";
         }
         $sql .= "NOW() )";
@@ -313,14 +311,12 @@ class ALERT {
 						");
                     return 1;
                 }
-            }
-            else {
+            } else {
                 // Couldn't add the registration token to the DB.
                 return -1;
             }
 
-        }
-        else {
+        } else {
             // Couldn't add the user's data to the DB.
             return -1;
         }
@@ -367,8 +363,7 @@ class ALERT {
         $success = send_template_email($data, $merge);
         if ($success) {
             return TRUE;
-        }
-        else {
+        } else {
             return FALSE;
         }
     }
@@ -383,12 +378,10 @@ class ALERT {
             $q = $this->db->query("SELECT alert_id FROM alerts WHERE email='" . $this->db->escape($email) . "'");
             if ($q->rows() > 0) {
                 return TRUE;
-            }
-            else {
+            } else {
                 return FALSE;
             }
-        }
-        else {
+        } else {
             return FALSE;
         }
 
@@ -406,8 +399,7 @@ class ALERT {
         // Split the token into its parts.
         if (strstr($token, '::')) {
             $arg = '::';
-        }
-        else {
+        } else {
             $arg = '-';
         }
         $token_parts = explode($arg, $token);
@@ -437,12 +429,10 @@ class ALERT {
             if ($r->success()) {
                 $this->confirmed = TRUE;
                 return TRUE;
-            }
-            else {
+            } else {
                 return FALSE;
             }
-        }
-        else {
+        } else {
             // Couldn't find this alert in the DB. Maybe the token was
             // wrong or incomplete?
             return FALSE;
@@ -460,8 +450,7 @@ class ALERT {
         // Split the token into its parts.
         if (strstr($token, '::')) {
             $arg = '::';
-        }
-        else {
+        } else {
             $arg = '-';
         }
         $bits = explode($arg, $token);
@@ -493,14 +482,12 @@ class ALERT {
                 $this->deleted = TRUE;
                 return TRUE;
 
-            }
-            else {
+            } else {
                 // Couldn't delete this alert in the DB.
                 return FALSE;
             }
 
-        }
-        else {
+        } else {
             // Couldn't find this alert in the DB. Maybe the token was
             // wrong or incomplete?
             return FALSE;
@@ -539,8 +526,7 @@ class ALERT {
             if (preg_match('#^speaker:(\d+)#', $c, $m)) {
                 $MEMBER = new MEMBER(['person_id' => $m[1]]);
                 $spokenby = $MEMBER->full_name();
-            }
-            else {
+            } else {
                 $words[] = $c;
             }
         }
@@ -571,4 +557,5 @@ class ALERT {
     // PRIVATE FUNCTIONS BELOW... ////////////////.
 
 
-} // End USER class
+// End USER class.
+}

--- a/www/includes/easyparliament/comment.php
+++ b/www/includes/easyparliament/comment.php
@@ -56,8 +56,7 @@ class COMMENT {
         // Set in init.php.
         if (ALLOWCOMMENTS == TRUE) {
             $this->comments_enabled = TRUE;
-        }
-        else {
+        } else {
             $this->comments_enabled = FALSE;
         }
 
@@ -89,8 +88,7 @@ class COMMENT {
                 $this->_set_username();
 
                 $this->exists = TRUE;
-            }
-            else {
+            } else {
                 $this->exists = FALSE;
             }
         }
@@ -280,8 +278,7 @@ class COMMENT {
 
             return $this->comment_id();
 
-        }
-        else {
+        } else {
             return FALSE;
         }
     }
@@ -329,8 +326,7 @@ class COMMENT {
             $date = NULL;
             $flag = 'NULL';
 
-        }
-        else {
+        } else {
             $PAGE->error_message("Why are you trying to switch this comment's modflag to '" . htmlentities($switch) . "'!");
         }
 
@@ -342,8 +338,7 @@ class COMMENT {
         if ($q->success()) {
             $this->modflagged = $date;
             return TRUE;
-        }
-        else {
+        } else {
             $message = [
                 'title' => 'Sorry',
                 'text' => "We couldn't update the comment's modflag."
@@ -367,8 +362,7 @@ class COMMENT {
 
             if ($q->success()) {
                 return TRUE;
-            }
-            else {
+            } else {
                 $message = [
                     'title' => 'Sorry',
                     'text' => "We were unable to delete the comment."
@@ -377,8 +371,7 @@ class COMMENT {
                 return FALSE;
             }
 
-        }
-        else {
+        } else {
             $message = [
                 'title' => 'Sorry',
                 'text' => "You are not authorised to delete comments."

--- a/www/includes/easyparliament/glossary.php
+++ b/www/includes/easyparliament/glossary.php
@@ -158,8 +158,7 @@ class GLOSSARY {
             }
 
             return ($this->num_terms);
-        }
-        else {
+        } else {
             return FALSE;
         }
     }
@@ -274,8 +273,7 @@ class GLOSSARY {
 
         if ($success) {
             return ($success);
-        }
-        else {
+        } else {
             return FALSE;
         }
     }
@@ -337,8 +335,7 @@ class GLOSSARY {
             // Catch glossary terms within their own definitions.
             if ($glossary_id == $this->glossary_id) {
                 $replacewords[] = "<strong>\\1</strong>";
-            }
-            else {
+            } else {
                 if ($this_page == "admin_glossary") {
                     $link_url = "#gl" . $glossary_id;
                 }
@@ -377,8 +374,7 @@ class GLOSSARY {
             foreach ($body as $i => $t) {
                 $body[$i] = antiTagInTag($t);
             }
-        }
-        else {
+        } else {
             $body = antiTagInTag($body);
         }
         return $body;

--- a/www/includes/easyparliament/hansardlist.php
+++ b/www/includes/easyparliament/hansardlist.php
@@ -203,8 +203,7 @@ class HANSARDLIST {
         // Not every possible view here has a mobile version. So, only use the mobile version template if it exists.
         if ($mobile && file_exists($mobile_template)) {
             include $mobile_template;
-        }
-        else {
+        } else {
             include $standard_template;
         }
         return TRUE;
@@ -331,8 +330,7 @@ class HANSARDLIST {
                 $sectiondata = $sectiondata[0];
             }
 
-        }
-        else {
+        } else {
             // This item *is* a section, so just return that.
 
             $sectiondata = $itemdata;
@@ -371,8 +369,7 @@ class HANSARDLIST {
             $subsectiondata = $this->_get_hansard_data($input);
             if (count($subsectiondata) == 0) {
                 $subsectiondata = NULL;
-            }
-            else {
+            } else {
                 $subsectiondata = $subsectiondata[0];
             }
 
@@ -566,8 +563,7 @@ class HANSARDLIST {
                 'title' => '',
                 'url' => $URL->generate()
             ];
-        }
-        else {
+        } else {
             // We'll be setting $nextprevdata['up'] within $this->get_data_by_gid()
             // because we need to know the name and url of the parent item, which
             // we don't have here. Life sucks.
@@ -604,8 +600,7 @@ class HANSARDLIST {
 							WHERE 	major = '" . $this->major . "'
 							AND		hdate > '" . $this->db->escape($date) . "'
 							");
-            }
-            else {
+            } else {
                 $q = $this->db->query("SELECT MAX(hdate) AS hdate
 							FROM 	hansard
 							WHERE 	major = '" . $this->major . "'
@@ -663,8 +658,7 @@ class HANSARDLIST {
 
         if (isset($args['date'])) {
             $date = $args['date'];
-        }
-        else {
+        } else {
             $PAGE->error_message("Sorry, we don't have a date.");
             return FALSE;
         }
@@ -720,8 +714,7 @@ class HANSARDLIST {
         $q = $this->db->query("SELECT gid_to FROM gidredirect WHERE gid_from = '" . $this->db->escape($gid) . "'");
         if ($q->rows() == 0) {
             $itemdata = $this->_get_hansard_data($input);
-        }
-        else {
+        } else {
             do {
                 $gid = $q->field(0, 'gid_to');
                 $q = $this->db->query("SELECT gid_to FROM gidredirect WHERE gid_from = '" . $this->db->escape($gid) . "'");
@@ -947,8 +940,7 @@ class HANSARDLIST {
 
         if (isset($args['days']) && is_numeric($args['days'])) {
             $limit = 'LIMIT ' . $args['days'];
-        }
-        else {
+        } else {
             $limit = '';
         }
 
@@ -1009,8 +1001,7 @@ class HANSARDLIST {
 
         if (isset($this->major)) {
             $majorwhere = "AND hansard.major = '" . $this->major . "' ";
-        }
-        else {
+        } else {
             // We're getting results for all debates/wrans/etc.
             $majorwhere = '';
         }
@@ -1072,8 +1063,7 @@ class HANSARDLIST {
                 }
             }
             $data['rows'] = $speeches;
-        }
-        else {
+        } else {
             $data['rows'] = [];
         }
         return $data;
@@ -1103,8 +1093,7 @@ class HANSARDLIST {
             // $args['s'] should have been tidied up by the time we get here.
             // eg, by doing filter_user_input($s, 'strict');
             $searchstring = $args['s'];
-        }
-        else {
+        } else {
             $PAGE->error_message("No search string");
             return FALSE;
         }
@@ -1118,8 +1107,7 @@ class HANSARDLIST {
         // Mainly for glossary term adding.
         if (isset($args['num']) && $args['num']) {
             $results_per_page = $args['num'];
-        }
-        else {
+        } else {
             $results_per_page = 20;
         }
         if ($results_per_page > 1000) {
@@ -1131,16 +1119,14 @@ class HANSARDLIST {
         // What page are we on?
         if (isset($args['p']) && is_numeric($args['p'])) {
             $page = $args['p'];
-        }
-        else {
+        } else {
             $page = 1;
         }
         $data['info']['page'] = $page;
 
         if (isset($args['e'])) {
             $encode = 'url';
-        }
-        else {
+        } else {
             $encode = 'html';
         }
 
@@ -1338,8 +1324,7 @@ class HANSARDLIST {
                     $itemdata['body'] = '';
                 }
 
-            }
-            else {
+            } else {
                 // Wrans or WMS.
                 $section = $this->_get_section($itemdata);
                 $subsection = $this->_get_subsection($itemdata);
@@ -1438,14 +1423,12 @@ class HANSARDLIST {
             if (isset($args['month']) && is_numeric($args['month'])) {
                 // A particular month.
                 $action = 'month';
-            }
-            else {
+            } else {
                 // A single year.
                 $action = 'year';
             }
 
-        }
-        else {
+        } else {
             // The year to date so far.
             $action = 'recentyear';
         }
@@ -1478,8 +1461,7 @@ class HANSARDLIST {
 
             if ($q->field(0, 'hdate') != NULL) {
                 $recentdate = $q->field(0, 'hdate');
-            }
-            else {
+            } else {
                 $PAGE->error_message("Couldn't find the most recent date");
                 return $data;
             }
@@ -1508,8 +1490,7 @@ class HANSARDLIST {
                     $firstmonth = 12 + $firstmonth;
                 };
 
-            }
-            else {
+            } else {
                 // $action == 'recentyear'
 
                 // Get the most recent year's results.
@@ -1517,8 +1498,7 @@ class HANSARDLIST {
                 $firstmonth = 1;
             }
 
-        }
-        else {
+        } else {
             // $action == 'year' or 'month'.
 
             $firstyear = $args['year'];
@@ -1527,8 +1507,7 @@ class HANSARDLIST {
             if ($action == 'month') {
                 $firstmonth = intval($args['month']);
                 $finalmonth = intval($args['month']);
-            }
-            else {
+            } else {
                 $firstmonth = 1;
                 $finalmonth = 12;
             }
@@ -1554,8 +1533,7 @@ class HANSARDLIST {
 
         if ($finalyear > $firstyear || $finalmonth >= $firstmonth) {
             $where = "AND hdate <= '" . $this->db->escape($finalyear) . "-" . $this->db->escape($finalmonth) . "-31'";
-        }
-        else {
+        } else {
             $where = '';
         }
 
@@ -1739,8 +1717,7 @@ class HANSARDLIST {
         ) {
             $fieldsarr['epobject'] = ['body'];
             $join = 'LEFT OUTER JOIN epobject ON hansard.epobject_id = epobject.epobject_id';
-        }
-        else {
+        } else {
             $join = '';
         }
 
@@ -1955,8 +1932,7 @@ class HANSARDLIST {
 
         if ($q->rows() > 0) {
             $votes['user']['yes'] = $q->field(0, 'totalvotes');
-        }
-        else {
+        } else {
             $votes['user']['yes'] = '0';
         }
 
@@ -1969,8 +1945,7 @@ class HANSARDLIST {
 
         if ($q->rows() > 0) {
             $votes['user']['no'] = $q->field(0, 'totalvotes');
-        }
-        else {
+        } else {
             $votes['user']['no'] = '0';
         }
 
@@ -1984,8 +1959,7 @@ class HANSARDLIST {
         if ($q->rows() > 0) {
             $votes['anon']['yes'] = $q->field(0, 'yes_votes');
             $votes['anon']['no'] = $q->field(0, 'no_votes');
-        }
-        else {
+        } else {
             $votes['anon']['yes'] = '0';
             $votes['anon']['no'] = '0';
         }
@@ -2013,8 +1987,7 @@ class HANSARDLIST {
         // $url_args is an array of other key/value pairs to be appended in the GET string.
         if ($id_data['major']) {
             $LISTURL = new URL($hansardmajors[$id_data['major']]['page_all']);
-        }
-        else {
+        } else {
             $LISTURL = new URL('wrans');
         }
 
@@ -2025,12 +1998,10 @@ class HANSARDLIST {
                 $id = preg_replace('#^.*?_.*?_#', '', $id_data['gid']);
                 $fragment = $this->url . '/' . $id;
                 $LISTURL->remove(['id']);
-            }
-            else {
+            } else {
                 $LISTURL->insert(['id' => $id_data['gid']]);
             }
-        }
-        else {
+        } else {
             // A debate speech or question/answer, etc.
             // We need to get the gid of the parent (sub)section for this item.
             // We use this with the gid of the item itself as an #anchor.
@@ -2045,8 +2016,7 @@ class HANSARDLIST {
 
                 $parent_gid = $this->epobjectid_to_gid[$parent_epobject_id];
 
-            }
-            else {
+            } else {
                 // We haven't cached the gid, so fetch from db.
 
                 $r = $this->db->query("SELECT gid
@@ -2165,13 +2135,11 @@ class HANSARDLIST {
                 else {
                     return [];
                 }
-            }
-            else {
+            } else {
                 // Already cached, so just return that.
                 return $this->speakers[$speaker_id];
             }
-        }
-        else {
+        } else {
             return [];
         }
     }
@@ -2265,8 +2233,7 @@ class HANSARDLIST {
                 $where .= " AND section_id = '" . $item_data['epobject_id'] . "'";
             }
 
-        }
-        else {
+        } else {
             // Just getting a count of the comments on this item.
             $from = "comments";
             $where = "epobject_id = '" . $this->db->escape($item_data['epobject_id']) . "'";
@@ -2439,8 +2406,7 @@ class HANSARDLIST {
             elseif ($itemdata['htype'] == '11') {
                 $nextprev = $this->_get_nextprev_items($subsectionrow);
 
-            }
-            else {
+            } else {
                 // Ordinary lowly item.
                 $nextprev = $this->_get_nextprev_items($itemdata);
 
@@ -2736,16 +2702,14 @@ class DEBATELIST extends HANSARDLIST {
         // The most voted on things during how many recent days?
         if (isset($args['days']) && is_numeric($args['days'])) {
             $days = $args['days'];
-        }
-        else {
+        } else {
             $days = 7;
         }
 
         // How many results?
         if (isset($args['num']) && is_numeric($args['num'])) {
             $items_to_list = $args['num'];
-        }
-        else {
+        } else {
             $items_to_list = 5;
         }
 
@@ -2824,9 +2788,7 @@ class DEBATELIST extends HANSARDLIST {
             }
 
             $data['rows'] = $speeches;
-
-        }
-        else {
+        } else {
             $data['rows'] = [];
         }
 
@@ -2883,8 +2845,7 @@ class DEBATELIST extends HANSARDLIST {
 
         if ($args['num'] == 1) {
             $datewhere = "h.hdate = '" . $this->db->escape($recentday['hdate']) . "'";
-        }
-        else {
+        } else {
             $firstdate = gmdate('Y-m-d', $recentday['timestamp'] - (86400 * $args['days']));
             $datewhere = "h.hdate >= '" . $this->db->escape($firstdate) . "'
 						AND		h.hdate <= '" . $this->db->escape($recentday['hdate']) . "'";
@@ -3082,8 +3043,7 @@ class WRANSLIST extends HANSARDLIST {
 
         if ($args['num'] == 1) {
             $datewhere = "h.hdate = '" . $this->db->escape($recentday['hdate']) . "'";
-        }
-        else {
+        } else {
             $firstdate = gmdate('Y-m-d', $recentday['timestamp'] - (86400 * $args['days']));
             $datewhere = "h.hdate >= '" . $this->db->escape($firstdate) . "'
 						AND		h.hdate <= '" . $this->db->escape($recentday['hdate']) . "'";
@@ -3092,8 +3052,7 @@ class WRANSLIST extends HANSARDLIST {
         // Get a random selection of subsections in wrans.
         if ($hansardmajors[$this->major]['location'] == 'Scotland') {
             $htype = 'htype = 10 and section_id = 0';
-        }
-        else {
+        } else {
             $htype = 'htype = 11 and section_id != 0';
         }
         $q = $this->db->query("SELECT e.body,
@@ -3220,8 +3179,7 @@ class StandingCommittee extends DEBATELIST {
             ];
             if ($chairman) {
                 $comm['chairmen'][$member_id] = $arr;
-            }
-            else {
+            } else {
                 $comm['members'][$member_id] = $arr;
             }
         }

--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -89,18 +89,14 @@ class MEMBER {
         $person_id = '';
         if (isset($args['member_id']) && is_numeric($args['member_id'])) {
             $person_id = $this->member_id_to_person_id($args['member_id']);
-        }
-        elseif (isset($args['name'])) {
+        } elseif (isset($args['name'])) {
             $con = $args['constituency'] ?? '';
             $person_id = $this->name_to_person_id($args['name'], $con);
-        }
-        elseif (isset($args['constituency'])) {
+        } elseif (isset($args['constituency'])) {
             $person_id = $this->constituency_to_person_id($args['constituency']);
-        }
-        elseif (isset($args['postcode'])) {
+        } elseif (isset($args['postcode'])) {
             $person_id = $this->postcode_to_person_id($args['postcode']);
-        }
-        elseif (isset($args['person_id']) && is_numeric($args['person_id'])) {
+        } elseif (isset($args['person_id']) && is_numeric($args['person_id'])) {
             $person_id = $args['person_id'];
         }
 
@@ -114,8 +110,7 @@ class MEMBER {
                 // Hohoho, how long will I get away with this for?
                 // Not very long, it made Lord Patel go wrong.
                 $person_id = $person_id[0];
-            }
-            else {
+            } else {
                 $this->valid = FALSE;
                 $this->person_id = $person_id;
                 return;
@@ -230,8 +225,7 @@ class MEMBER {
 					WHERE member_id = '" . $this->db->escape($member_id) . "'");
         if ($q->rows > 0) {
             return $q->field(0, 'person_id');
-        }
-        else {
+        } else {
             // $PAGE->error_message("Sorry, there is no member with a member ID of '" . htmlentities($member_id) . "'.");
             return FALSE;
         }
@@ -271,13 +265,11 @@ class MEMBER {
 
         if ($q->rows > 0) {
             return $q->field(0, 'person_id');
-        }
-        else {
+        } else {
             $q = $this->db->query("SELECT person_id FROM member WHERE constituency = '" . $this->db->escape($constituency) . "' ORDER BY left_house DESC LIMIT 1");
             if ($q->rows > 0) {
                 return $q->field(0, 'person_id');
-            }
-            else {
+            } else {
                 // $PAGE->error_message("Sorry, there is no current member for the '" . htmlentities(html_entity_decode($constituency)) . "' constituency.");
                 return FALSE;
             }
@@ -327,8 +319,7 @@ class MEMBER {
             $q .= "house = 4 AND (";
             $q .= "(first_name='$first_name $middle_name' AND last_name='$last_name')";
             $q .= " or (first_name='$first_name' AND last_name='$middle_name $last_name') )";
-        }
-        elseif ($this_page == 'mla') {
+        } elseif ($this_page == 'mla') {
             $success = preg_match('#^(.*?) (.*?) (.*?)$#', $name, $m);
             if (!$success) {
                 $success = preg_match('#^(.*?)() (.*)$#', $name, $m);
@@ -343,8 +334,7 @@ class MEMBER {
             $q .= "house = 3 AND (";
             $q .= "(first_name='$first_name $middle_name' AND last_name='$last_name')";
             $q .= " or (first_name='$first_name' AND last_name='$middle_name $last_name') )";
-        }
-        elseif (strstr($this_page, 'mp') || $this_page == 'peer') {
+        } elseif (strstr($this_page, 'mp') || $this_page == 'peer') {
             $success = preg_match('#^(.*?) (.*?) (.*?)$#', $name, $m);
             if (!$success) {
                 $success = preg_match('#^(.*?)() (.*)$#', $name, $m);
@@ -358,8 +348,7 @@ class MEMBER {
             $last_name = $m[3];
             if (strstr($this_page, 'mp')) {
                 $house = 1;
-            }
-            else {
+            } else {
                 $house = 2;
             }
             // If ($title) $q .= 'title = \'' . $this->db->escape($title) . '\' AND ';.
@@ -372,8 +361,7 @@ class MEMBER {
                     $const = $normalised;
                 }
             }
-        }
-        elseif ($this_page == 'royal') {
+        } elseif ($this_page == 'royal') {
             $q .= ' house = 0';
         }
 
@@ -400,15 +388,12 @@ class MEMBER {
             }
             $this->constituency = $consts;
             return $person_ids;
-        }
-        elseif ($q->rows > 0) {
+        } elseif ($q->rows > 0) {
             return $q->field(0, 'person_id');
-        }
-        elseif ($const && $this_page != 'peer') {
+        } elseif ($const && $this_page != 'peer') {
             $this->canonical = FALSE;
             return $this->name_to_person_id($name);
-        }
-        else {
+        } else {
             $PAGE->error_message("Sorry, there is no current member with that name.");
             return FALSE;
         }
@@ -659,8 +644,7 @@ class MEMBER {
         }
         if (isset($parties[$party])) {
             return $parties[$party];
-        }
-        else {
+        } else {
             return $party;
         }
     }
@@ -685,11 +669,9 @@ class MEMBER {
         [$year, $month, $day] = explode('-', $entered_house);
         if ($month == 1 && $day == 1 && $this->house(2)) {
             return $year;
-        }
-        elseif (checkdate($month, $day, $year) && $year != '9999') {
+        } elseif (checkdate($month, $day, $year) && $year != '9999') {
             return format_date($entered_house, LONGDATEFORMAT);
-        }
-        else {
+        } else {
             return "n/a";
         }
     }
@@ -714,8 +696,7 @@ class MEMBER {
         [$year, $month, $day] = explode('-', $left_house);
         if (checkdate($month, $day, $year) && $year != '9999') {
             return format_date($left_house, LONGDATEFORMAT);
-        }
-        else {
+        } else {
             return "n/a";
         }
     }
@@ -733,8 +714,7 @@ class MEMBER {
     public function entered_reason_text($entered_reason) {
         if (isset($this->reasons[$entered_reason])) {
             return $this->reasons[$entered_reason];
-        }
-        else {
+        } else {
             return $entered_reason;
         }
     }
@@ -757,16 +737,13 @@ class MEMBER {
                 $max = $q->field(0, 'max');
                 if ((!$mponly && $max == $this->left_house) || ($mponly && $max == $this->mp_left_house)) {
                     return $left_reason[0];
-                }
-                else {
+                } else {
                     return $left_reason[1];
                 }
-            }
-            else {
+            } else {
                 return $left_reason;
             }
-        }
-        else {
+        } else {
             return $left_reason;
         }
     }
@@ -807,24 +784,19 @@ class MEMBER {
         $house = $this->house_disp;
         if ($house == 1) {
             $URL = new URL('mp');
-        }
-        elseif ($house == 2) {
+        } elseif ($house == 2) {
             $URL = new URL('peer');
-        }
-        elseif ($house == 3) {
+        } elseif ($house == 3) {
             $URL = new URL('mla');
-        }
-        elseif ($house == 4) {
+        } elseif ($house == 4) {
             $URL = new URL('msp');
-        }
-        elseif ($house == 0) {
+        } elseif ($house == 0) {
             $URL = new URL('royal');
         }
         $member_url = make_member_url($this->full_name(TRUE), $this->constituency(), $house);
         if ($absolute) {
             return 'http://' . DOMAIN . $URL->generate('none') . $member_url;
-        }
-        else {
+        } else {
             return $URL->generate('none') . $member_url;
         }
     }
@@ -934,8 +906,7 @@ function party_to_colour($party) {
     global $party_colours;
     if (isset($party_colours[$party])) {
         return $party_colours[$party];
-    }
-    else {
+    } else {
         return "#eeeeee";
     }
 }
@@ -949,24 +920,19 @@ function find_rep_image($pid, $smallonly = FALSE) {
     if (!$smallonly && is_file(FILEIMAGEPATH . 'mpsL/' . $pid . '.jpg')) {
         $image = IMAGEPATH . 'mpsL/' . $pid . '.jpg';
         $sz = 'L';
-    }
-    elseif (!$smallonly && is_file(FILEIMAGEPATH . 'mpsL/' . $pid . '.jpeg')) {
+    } elseif (!$smallonly && is_file(FILEIMAGEPATH . 'mpsL/' . $pid . '.jpeg')) {
         $image = IMAGEPATH . 'mpsL/' . $pid . '.jpeg';
         $sz = 'L';
-    }
-    elseif (!$smallonly && is_file(FILEIMAGEPATH . 'mpsL/' . $pid . '.png')) {
+    } elseif (!$smallonly && is_file(FILEIMAGEPATH . 'mpsL/' . $pid . '.png')) {
         $image = IMAGEPATH . 'mpsL/' . $pid . '.png';
         $sz = 'L';
-    }
-    elseif (is_file(FILEIMAGEPATH . 'mps/' . $pid . '.jpg')) {
+    } elseif (is_file(FILEIMAGEPATH . 'mps/' . $pid . '.jpg')) {
         $image = IMAGEPATH . 'mps/' . $pid . '.jpg';
         $sz = 'S';
-    }
-    elseif (is_file(FILEIMAGEPATH . 'mps/' . $pid . '.jpeg')) {
+    } elseif (is_file(FILEIMAGEPATH . 'mps/' . $pid . '.jpeg')) {
         $image = IMAGEPATH . 'mps/' . $pid . '.jpeg';
         $sz = 'S';
-    }
-    elseif (is_file(FILEIMAGEPATH . 'mps/' . $pid . '.png')) {
+    } elseif (is_file(FILEIMAGEPATH . 'mps/' . $pid . '.png')) {
         $image = IMAGEPATH . 'mps/' . $pid . '.png';
         $sz = 'S';
     }

--- a/www/includes/easyparliament/people.php
+++ b/www/includes/easyparliament/people.php
@@ -35,8 +35,7 @@ class PEOPLE {
             // Get all the data that's to be rendered.
             $data = $this->$function($args);
 
-        }
-        else {
+        } else {
             $PAGE->error_message("You haven't specified a view type.");
             return FALSE;
         }
@@ -160,8 +159,7 @@ class PEOPLE {
             if (isset($data[$p_id])) {
                 $data[$p_id]['dept'] = array_merge((array) $data[$p_id]['dept'], (array) $dept);
                 $data[$p_id]['pos'] = array_merge((array) $data[$p_id]['pos'], (array) $pos);
-            }
-            else {
+            } else {
                 $narray = [
                     'person_id' => $p_id,
                     'title' => $q->field($row, 'title'),

--- a/www/includes/easyparliament/searchengine.php
+++ b/www/includes/easyparliament/searchengine.php
@@ -102,8 +102,7 @@ class SEARCHENGINE {
             ')/', $query, $all_words);
         if ($all_words) {
             $all_words = $all_words[0];
-        }
-        else {
+        } else {
             $all_words = [];
         }
         $in_quote = FALSE;
@@ -214,8 +213,7 @@ else {
             }
             elseif (count($this->words) == 2) {
                 $description .= $this->words[0] . "' and '" . $this->words[1];
-            }
-            else {
+            } else {
                 $description .= $this->words[0];
             }
             $description .= "'";
@@ -226,8 +224,7 @@ else {
                 if ($long) {
                     $description .= " containing";
                 }
-            }
-            else {
+            } else {
                 $description .= " and";
             }
             $description .= " the " . make_plural("phrase", count($this->phrases)) . " ";
@@ -237,8 +234,7 @@ else {
         if (count($this->excluded) > 0) {
             if (count($this->words) > 0 or count($this->phrases) > 0) {
                 $description .= " but not";
-            }
-            else {
+            } else {
                 $description .= " excluding";
             }
             $description .= " the " . make_plural("word", count($this->excluded));
@@ -294,8 +290,7 @@ else {
             elseif ($items[0] == 'batch') {
                 // Silently ignore, as description goes in email alerts
                 // $description .= ' in search batch ' . $items[1];.
-            }
-            else {
+            } else {
                 $PAGE->error_message("Unknown search prefix '$items[0]' ignored");
             }
         }

--- a/www/includes/easyparliament/searchlog.php
+++ b/www/includes/easyparliament/searchlog.php
@@ -22,16 +22,14 @@
  * Note that the url includes "pop=1" which stops popular searches feeding back
  * into being more popular.
  */
-class SEARCHLOG
-{
+class SEARCHLOG {
 
     private $db = NULL;
 
     /**
      *
      */
-    public function __construct()
-    {
+    public function __construct() {
         $this->SEARCHURL = new URL('search');
         $this->db = new ParlDB();
     }
@@ -39,8 +37,7 @@ class SEARCHLOG
     /**
      *
      */
-    public function add($searchlogdata)
-    {
+    public function add($searchlogdata) {
 
         $this->db->query("INSERT INTO search_query_log
             (query_string, page_number, count_hits, ip_address, query_time)
@@ -53,8 +50,7 @@ class SEARCHLOG
     /**
      * Select popular queries.
      */
-    public function popular_recent($count)
-    {
+    public function popular_recent($count) {
 
         $q = $this->db->query("
                 SELECT query_string, count(*) AS c
@@ -75,8 +71,7 @@ class SEARCHLOG
     /**
      *
      */
-    public function _db_row_to_array($q, $row)
-    {
+    public function _db_row_to_array($q, $row) {
         $query = $q->field($row, 'query_string');
         $this->SEARCHURL->insert(['s' => $query, 'pop' => 1]);
         $url = $this->SEARCHURL->generate();
@@ -102,8 +97,7 @@ class SEARCHLOG
     /**
      *
      */
-    public function admin_recent_searches($count)
-    {
+    public function admin_recent_searches($count) {
 
         $q = $this->db->query("SELECT query_string, page_number, count_hits, ip_address, query_time
                 FROM search_query_log ORDER BY query_time desc LIMIT $count");
@@ -117,8 +111,7 @@ class SEARCHLOG
     /**
      *
      */
-    public function admin_popular_searches($count)
-    {
+    public function admin_popular_searches($count) {
 
         $q = $this->db->query("SELECT *, count(*) AS c FROM search_query_log
                 WHERE count_hits != 0 AND query_string NOT LIKE '%speaker:%'
@@ -135,8 +128,7 @@ class SEARCHLOG
     /**
      *
      */
-    public function admin_failed_searches()
-    {
+    public function admin_failed_searches() {
 
         $q = $this->db->query("SELECT query_string, page_number, count_hits, ip_address, query_time,
                 COUNT(*) AS group_count, MIN(query_time) AS min_time, MAX(query_time) AS max_time,

--- a/www/includes/easyparliament/sidebars/calendar_hocdebates.php
+++ b/www/includes/easyparliament/sidebars/calendar_hocdebates.php
@@ -23,8 +23,7 @@ if ($this_page == 'debatesday') {
             'onday' => $date
         ];
         $title = 'Debates this month';
-    }
-    else {
+    } else {
         $args = [
             'months' => 1
         ];

--- a/www/includes/easyparliament/sidebars/calendar_whalldebates.php
+++ b/www/includes/easyparliament/sidebars/calendar_whalldebates.php
@@ -23,8 +23,7 @@ if ($this_page == 'whallday') {
             'onday' => $date
         ];
         $title = 'Westminster Hall debates this month';
-    }
-    else {
+    } else {
         $args = [
             'months' => 1
         ];

--- a/www/includes/easyparliament/sidebars/calendar_wms.php
+++ b/www/includes/easyparliament/sidebars/calendar_wms.php
@@ -23,8 +23,7 @@ if ($this_page == 'wmsday') {
             'onday' => $date
         ];
         $title = 'Written Ministerial Statements this month';
-    }
-    else {
+    } else {
         $args = [
             'months' => 1
         ];

--- a/www/includes/easyparliament/sidebars/calendar_wrans.php
+++ b/www/includes/easyparliament/sidebars/calendar_wrans.php
@@ -23,8 +23,7 @@ if ($this_page == 'wransday') {
             'onday' => $date
         ];
         $title = 'Answers this month';
-    }
-    else {
+    } else {
         $args = [
             'months' => 1
         ];

--- a/www/includes/easyparliament/skin.php
+++ b/www/includes/easyparliament/skin.php
@@ -92,8 +92,7 @@ class SKIN {
         if ($this_page == "skin" && get_http_var("newskin") != "") {
             // We only allow the reskinning on the "skin" page.
             $this->new_skin(get_http_var("newskin"));
-        }
-        else {
+        } else {
             $this->set_skin(get_cookie_var("skin"));
         }
 
@@ -126,8 +125,7 @@ class SKIN {
 
         if (isset($skin) && isset($this->skins[$skin])) {
             $this->skin = $skin;
-        }
-        else {
+        } else {
             $this->skin = "default";
         }
 

--- a/www/includes/easyparliament/templates/api/comments.php
+++ b/www/includes/easyparliament/templates/api/comments.php
@@ -43,16 +43,13 @@ if (isset($data['comments'][0]['preview']) && $data['comments'][0]['preview'] ==
     // If we're just previewing a comment, we passed in 'preview' => true.
     $subheading = 'Your comment would look like this:';
 
-}
-elseif ($this_page == 'addcomment') {
+} elseif ($this_page == 'addcomment') {
     $subheading = 'Previous comments';
 
-}
-elseif ($this_page == 'commentreport' || $this_page == 'admin_commentreport') {
+} elseif ($this_page == 'commentreport' || $this_page == 'admin_commentreport') {
     $subheading = "";
 
-}
-else {
+} else {
     $subheading = 'Comments';
 }
 
@@ -77,8 +74,7 @@ if (isset($data['comments']) && count($data['comments']) > 0) {
 
         if (isset($comment['comment_id'])) {
             $id = 'c' . $comment['comment_id'];
-        }
-        else {
+        } else {
             $id = '';
         }
 
@@ -108,8 +104,7 @@ if (isset($data['comments']) && count($data['comments']) > 0) {
                 if (isset($comment['url'])) {
                     print ' <a href="' . $comment['url'] . '" title="Link to this comment">' . $time . '</a>';
 
-                }
-                else {
+                } else {
                     // There won't be a URL when we're just previewing a comment.
                     print ' ' . $time;
                 }
@@ -133,8 +128,7 @@ if (isset($data['comments']) && count($data['comments']) > 0) {
     }
 
 
-}
-else {
+} else {
 
     ?>
     <div class="comment">

--- a/www/includes/easyparliament/templates/api/comments_user.php
+++ b/www/includes/easyparliament/templates/api/comments_user.php
@@ -42,8 +42,7 @@ if (isset($data['comments']) && count($data['comments']) > 0) {
         // Get the name of the member whose epobject was commented upon (if any).
         if (isset($comment['speaker']) && $comment['speaker']['first_name'] != '') {
             $member_name = $comment['speaker']['first_name'] . ' ' . $comment['speaker']['last_name'] . ': ';
-        }
-        else {
+        } else {
             $member_name = '';
         }
 
@@ -64,8 +63,7 @@ if (isset($data['comments']) && count($data['comments']) > 0) {
     $PAGE->page_links($data);
     $PAGE->stripe_end();
 
-}
-else {
+} else {
 
     $PAGE->stripe_start();
     ?>

--- a/www/includes/easyparliament/templates/api/hansard_date.php
+++ b/www/includes/easyparliament/templates/api/hansard_date.php
@@ -29,8 +29,7 @@ if (isset($data['rows'])) {
         }
         elseif ($row['htype'] == '11' && $hansardmajors[$row['major']]['type'] == 'other') {
             $has_content = TRUE;
-        }
-        else {
+        } else {
             $has_content = FALSE;
         }
 
@@ -39,8 +38,7 @@ if (isset($data['rows'])) {
             $entry['excerpt'] = trim_characters($entry['excerpt'], 0, 200);
         }
         if ($has_content) {
-        }
-        else {
+        } else {
             unset($entry['listurl']);
             unset($entry['commentsurl']);
             unset($entry['comment']);
@@ -49,8 +47,7 @@ if (isset($data['rows'])) {
 
         if ($row['htype'] == '10') {
             $out[] = ['entry' => $entry, 'subs' => []];
-        }
-        else {
+        } else {
             $out[count($out) - 1]['subs'][] = $entry;
         }
 

--- a/www/includes/easyparliament/templates/api/hansard_gid.php
+++ b/www/includes/easyparliament/templates/api/hansard_gid.php
@@ -62,8 +62,7 @@ if (isset($data['rows'])) {
             }
             elseif ($row['htype'] == '11' && $hansardmajors[$row['major']]['type'] == 'other') {
                 $has_content = TRUE;
-            }
-            else {
+            } else {
                 $has_content = FALSE;
             }
             $entry = $row;
@@ -71,8 +70,7 @@ if (isset($data['rows'])) {
                 $entry['excerpt'] = trim_characters($entry['excerpt'], 0, 200);
             }
             if ($has_content) {
-            }
-            else {
+            } else {
                 unset($entry['listurl']);
                 unset($entry['commentsurl']);
                 unset($entry['comment']);

--- a/www/includes/easyparliament/templates/csv/people_mlas.php
+++ b/www/includes/easyparliament/templates/csv/people_mlas.php
@@ -35,8 +35,7 @@ function render_mlas_row($mla, $order) {
     print $mla['person_id'] . ',' . ucfirst($name) . ',';
     if (array_key_exists($mla['party'], $parties)) {
         print $parties[$mla['party']];
-    }
-    else {
+    } else {
         print $mla['party'];
     }
     print ',' . $con . ',http://www.openaustralia.org/mla/' .

--- a/www/includes/easyparliament/templates/csv/people_mps.php
+++ b/www/includes/easyparliament/templates/csv/people_mps.php
@@ -54,16 +54,14 @@ function render_mps_row($mp, $order) {
         html_entity_decode($mp['last_name']) . ',';
     if (array_key_exists($mp['party'], $parties)) {
         print $parties[$mp['party']];
-    }
-    else {
+    } else {
         print $mp['party'];
     }
     print ',' . $con . ',http://' . DOMAIN . WEBPATH . 'mp/' .
         make_member_url($mp['first_name'] . ' ' . $mp['last_name'], $mp['constituency']);
     if ($order == 'expenses') {
         print ', �' . $mp['data_value'];
-    }
-    elseif ($order == 'debates') {
+    } elseif ($order == 'debates') {
         print ', ' . $mp['data_value'];
     }
     print "\n";

--- a/www/includes/easyparliament/templates/csv/people_peers.php
+++ b/www/includes/easyparliament/templates/csv/people_peers.php
@@ -32,8 +32,7 @@ function render_peers_row($peer, $order) {
     print $peer['person_id'] . ',' . ucfirst($name) . ',';
     if (array_key_exists($peer['party'], $parties)) {
         print $parties[$peer['party']];
-    }
-    else {
+    } else {
         print $peer['party'];
     }
     print ',http://' . DOMAIN . WEBPATH . 'senator/' . make_member_url($name, $peer['constituency']);

--- a/www/includes/easyparliament/trackback.php
+++ b/www/includes/easyparliament/trackback.php
@@ -46,8 +46,7 @@ class TRACKBACK {
         // Set in init.php.
         if (ALLOWTRACKBACKS == TRUE) {
             $this->trackbacks_enabled = TRUE;
-        }
-        else {
+        } else {
             $this->trackbacks_enabled = FALSE;
         }
     }
@@ -88,8 +87,7 @@ class TRACKBACK {
             // Get all the data that's to be rendered.
             $trackbackdata = $this->$function($args);
 
-        }
-        else {
+        } else {
             $PAGE->error_message("You haven't specified a valid view type.");
             return FALSE;
         }

--- a/www/includes/lib_filter.php
+++ b/www/includes/lib_filter.php
@@ -117,8 +117,7 @@ class lib_filter {
                         return '</' . $name . '>';
                     }
                 }
-            }
-            else {
+            } else {
                 return '';
             }
         }
@@ -161,8 +160,7 @@ class lib_filter {
                     $ending = ' /';
                 }
                 return '<' . $name . $params . $ending . '>';
-            }
-            else {
+            } else {
                 return '';
             }
         }

--- a/www/includes/mysql.php
+++ b/www/includes/mysql.php
@@ -172,8 +172,7 @@ class MySQLQuery {
 
                 return;
 
-            }
-            else {
+            } else {
 
                 // A successful SELECT, SHOW, EXPLAIN or DESCRIBE query.
                 $this->success = TRUE;
@@ -207,8 +206,7 @@ class MySQLQuery {
 
                 return;
             }
-        }
-        else {
+        } else {
             // There was an SQL error.
             return;
         }
@@ -248,8 +246,7 @@ class MySQLQuery {
             // New faster version.
             $result = $this->data[$row_index][$this->fieldnames_byname[$column_name]];
             return $result;
-        }
-        else {
+        } else {
             return "";
         }
     }
@@ -268,8 +265,7 @@ class MySQLQuery {
         if ($this->success) {
             $result = $this->_row_array($row_index);
             return $result;
-        }
-        else {
+        } else {
             return [];
         }
     }

--- a/www/includes/postcode.php
+++ b/www/includes/postcode.php
@@ -84,14 +84,12 @@ function postcode_to_constituency_internal($postcode) {
     if ($q->rows == 1) {
         $name = $q->field(0, 'name');
         return $name;
-    }
-    elseif ($q->rows > 1) {
+    } elseif ($q->rows > 1) {
         for ($i = 0; $i < $q->rows; $i++) {
             $name[] = $q->field($i, 'name');
         }
         return $name;
-    }
-    else {
+    } else {
         return '';
     }
 }

--- a/www/includes/technorati.php
+++ b/www/includes/technorati.php
@@ -160,16 +160,13 @@ function character1Data($parser, $data) {
         $arItems[$itemCount] = new xItem();
         // Set new item object's properties.
         $arItems[$itemCount]->xTitle = $data;
-    }
-    elseif ($curTag == $permalinkKey) {
+    } elseif ($curTag == $permalinkKey) {
         $arItems[$itemCount]->xPermalink = $data;
         // $itemCount++;
-    }
-    elseif ($curTag == $linkKey) {
+    } elseif ($curTag == $linkKey) {
         $arItems[$itemCount]->xLink = $data;
         // $itemCount++;
-    }
-    elseif ($curTag == $createdKey) {
+    } elseif ($curTag == $createdKey) {
         $arItems[$itemCount]->xCreated = $data;
         $itemCount++;
     }

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -40,8 +40,7 @@ function twfy_debug($header, $text = "") {
 
         if ($debug_level > count($levels)) {
             $max_level_to_show = count($levels);
-        }
-        else {
+        } else {
             $max_level_to_show = $debug_level;
         }
 
@@ -99,20 +98,17 @@ function error_handler(string $errno, string $errmsg, string $filename, int $lin
     $err = '';
     if (isset($_SERVER['REQUEST_URI'])) {
         $err .= "URL:\t\thttp://" . DOMAIN . $_SERVER['REQUEST_URI'] . "\n";
-    }
-    else {
+    } else {
         $err .= "URL:\t\tNone - running from command line?\n";
     }
     if (isset($_SERVER['HTTP_REFERER'])) {
         $err .= "Referer:\t" . $_SERVER['HTTP_REFERER'] . "\n";
-    }
-    else {
+    } else {
         $err .= "Referer:\tNone\n";
     }
     if (isset($_SERVER['HTTP_USER_AGENT'])) {
         $err .= "User-Agent:\t" . $_SERVER['HTTP_USER_AGENT'] . "\n";
-    }
-    else {
+    } else {
         $err .= "User-Agent:\tNone\n";
     }
     $err .= "Number:\t\t$errno\n";
@@ -159,8 +155,7 @@ function error_handler(string $errno, string $errmsg, string $filename, int $lin
     $fatal_errors = [E_ERROR, E_USER_ERROR];
     if (in_array($errno, $fatal_errors)) {
         $fatal = TRUE;
-    }
-    else {
+    } else {
         $fatal = FALSE;
     }
 
@@ -191,8 +186,7 @@ function error_handler(string $errno, string $errmsg, string $filename, int $lin
 
         if (is_object($PAGE)) {
             $PAGE->error_message($message, $fatal);
-        }
-        else {
+        } else {
             print "<p>Oops, sorry, an error has occurred!</p>\n";
         }
 
@@ -292,8 +286,7 @@ function validate_email($string) {
             '[-!#$%&\'*+\\.\\0-9=?A-Z^_`a-z{|}~]+$/', $string)
     ) {
         return FALSE;
-    }
-    else {
+    } else {
         return TRUE;
     }
 }
@@ -307,8 +300,7 @@ function validate_postcode($postcode) {
     $num = '0123456789';
     if (preg_match("/^[$num][$num][$num][$num]/", $postcode)) {
         return TRUE;
-    }
-    else {
+    } else {
         return FALSE;
     }
 }
@@ -357,8 +349,7 @@ function format_timestamp($timestamp, $format) {
         [$string, $year, $month, $day, $hour, $min, $sec] = $matches;
 
         return gmdate($format, gmmktime($hour, $min, $sec, $month, $day, $year));
-    }
-    else {
+    } else {
         return "";
     }
 
@@ -376,8 +367,7 @@ function format_date($date, $format) {
         [$string, $year, $month, $day] = $matches;
 
         return gmdate($format, gmmktime(0, 0, 0, $month, $day, $year));
-    }
-    else {
+    } else {
         return "";
     }
 
@@ -395,8 +385,7 @@ function format_time($time, $format) {
         [$string, $hour, $min, $sec] = $matches;
 
         return gmdate($format, gmmktime($hour, $min, $sec));
-    }
-    else {
+    } else {
         return "";
     }
 }
@@ -435,29 +424,24 @@ function relative_time($datetime) {
         $date = substr($datetime, 0, 10);
         return format_date($date, LONGDATEFORMAT);
 
-    }
-    else {
+    } else {
         $relative_date = '';
         if ($weeks > 0) {
             // Weeks and days.
             $relative_date .= ($relative_date ? ', ' : '') . $weeks . ' week' . ($weeks > 1 ? 's' : '');
             $relative_date .= $days > 0 ? ($relative_date ? ', ' : '') . $days . ' day' . ($days > 1 ? 's' : '') : '';
-        }
-        elseif ($days > 0) {
+        } elseif ($days > 0) {
             // Days and hours.
             $relative_date .= ($relative_date ? ', ' : '') . $days . ' day' . ($days > 1 ? 's' : '');
             $relative_date .= $hours > 0 ? ($relative_date ? ', ' : '') . $hours . ' hour' . ($hours > 1 ? 's' : '') : '';
-        }
-        elseif ($hours > 0) {
+        } elseif ($hours > 0) {
             // Hours and minutes.
             $relative_date .= ($relative_date ? ', ' : '') . $hours . ' hour' . ($hours > 1 ? 's' : '');
             $relative_date .= $minutes > 0 ? ($relative_date ? ', ' : '') . $minutes . ' minute' . ($minutes > 1 ? 's' : '') : '';
-        }
-        elseif ($minutes > 0) {
+        } elseif ($minutes > 0) {
             // Minutes only.
             $relative_date .= ($relative_date ? ', ' : '') . $minutes . ' minute' . ($minutes > 1 ? 's' : '');
-        }
-        else {
+        } else {
             // Seconds only.
             $relative_date .= ($relative_date ? ', ' : '') . $seconds . ' second' . ($seconds > 1 ? 's' : '');
         }
@@ -490,18 +474,15 @@ function parse_date($date) {
         if ($year < 100) {
             $year += 2000;
         }
-    }
-    elseif (preg_match('#(\d+)/(\d+)#', $date, $m)) {
+    } elseif (preg_match('#(\d+)/(\d+)#', $date, $m)) {
         $day = $m[1];
         $month = $m[2];
         $year = date('Y');
-    }
-    elseif (preg_match('#^([0123][0-9])([01][0-9])([0-9][0-9])$#', $date, $m)) {
+    } elseif (preg_match('#^([0123][0-9])([01][0-9])([0-9][0-9])$#', $date, $m)) {
         $day = $m[1];
         $month = $m[2];
         $year = $m[3];
-    }
-    else {
+    } else {
         // 0 Sunday, 6 Saturday
         $dayofweek = date('w');
         if (preg_match('#next\s+(sun|sunday|mon|monday|tue|tues|tuesday|wed|wednes|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday)\b#i', $date, $m)) {
@@ -511,8 +492,7 @@ function parse_date($date) {
             }
             elseif ($dayofweek == 4) {
                 $now = strtotime('4 days', $now);
-            }
-            else {
+            } else {
                 $now = strtotime('5 days', $now);
             }
         }
@@ -633,8 +613,7 @@ function filter_user_input($text, $filter_type) {
         // No tags allowed at all!
         $filter->allowed = [];
 
-    }
-    else {
+    } else {
         // Comment.
         // Only allowing <b> and <i> tags.
         $filter->allowed = [
@@ -729,8 +708,7 @@ function fix_gid_from_db($gid, $keepmajor = FALSE) {
     if ($keepmajor) {
         $newgid = substr($gid, strpos($gid, '/') + 1);
         $newgid = str_replace('/', '_', $newgid);
-    }
-    else {
+    } else {
         $newgid = substr($gid, strrpos($gid, '/') + 1);
     }
 
@@ -810,19 +788,16 @@ function send_template_email($data, $merge, $bulk = FALSE) {
     if (preg_match("/Subject:/", $firstline)) {
         if (isset($data['subject'])) {
             $subject = trim($data['subject']);
-        }
-        else {
+        } else {
             $subject = trim(substr($firstline, 8));
         }
 
         // Either way, remove this subject line from the template.
         $emailtext = substr($emailtext, strpos($emailtext, "\n"));
 
-    }
-    elseif (isset($data['subject'])) {
+    } elseif (isset($data['subject'])) {
         $subject = $data['subject'];
-    }
-    else {
+    } else {
         $PAGE->error_message("We don't have a subject line for the email, so it wasn't sent.");
         return FALSE;
     }
@@ -907,8 +882,7 @@ function recursive_strip($a) {
         foreach ($a as $key => $val) {
             $a[$key] = recursive_strip($val);
         }
-    }
-    else {
+    } else {
         $a = stripslashes($a);
     }
     return $a;
@@ -999,8 +973,7 @@ function make_member_url($name, $const = '', $house = 1) {
     $out = urlencode(str_replace($s, $r, $name));
     if ($const && ($house == 1 || $house == 2)) {
         $out .= '/' . urlencode(str_replace($s, $r, strtolower($const)));
-    }
-    elseif ($house == 0) {
+    } elseif ($house == 0) {
         $out = 'elizabeth_the_second';
     }
     return $out;
@@ -1052,8 +1025,7 @@ function prettify_office($pos, $dept) {
         if (array_key_exists($pretty, $lookup)) {
             $pretty = $lookup[$pretty];
         }
-    }
-    elseif ($pos) {
+    } elseif ($pos) {
         $pretty = $pos;
     }
     // Member of Select Committee.
@@ -1087,8 +1059,7 @@ function major_summary($data, $limit = "") {
             }
             elseif ($todaystime - $array['timestamp'] <= (6 * 86400)) {
                 $daytext[$major] = gmdate('l', $array['timestamp']) . "'s";
-            }
-            else {
+            } else {
                 $daytext[$major] = "The most recent ";
             }
         }
@@ -1104,8 +1075,7 @@ function major_summary($data, $limit = "") {
 
         if ($one_date) {
             $date = $data['date'];
-        }
-        else {
+        } else {
             $date = $data[$printed_majors[0]]['hdate'];
         }
         $q = $db->query('SELECT major, body, gid
@@ -1143,8 +1113,7 @@ function major_summary($data, $limit = "") {
     if (array_key_exists(4, $data)) {
         if ($one_date) {
             $date = $data['date'];
-        }
-        else {
+        } else {
             $date = $data[4]['hdate'];
         }
         $q = $db->query('SELECT section_id, body, gid FROM hansard,epobject
@@ -1164,8 +1133,7 @@ function major_summary($data, $limit = "") {
                     }
                     print '<li>' . $body . '<ul>';
 
-                }
-                else {
+                } else {
                     $LISTURL->insert(['id' => $gid]);
                     print '<li><a href="' . $LISTURL->generate() . '">';
                     print $body . '</a>';
@@ -1189,8 +1157,7 @@ function _major_summary_title($major, $data, $LISTURL, $daytext) {
     print '<a href="';
     if (isset($data[$major]['listurl'])) {
         print $data[$major]['listurl'];
-    }
-    else {
+    } else {
         print $LISTURL->generate();
     }
     print '">' . $hansardmajors[$major]['title'] . '</a>';

--- a/www/includes/wikipedia.php
+++ b/www/includes/wikipedia.php
@@ -153,8 +153,7 @@ function antiTagInTag($content = '', $format = 'htmlhead') {
         $tagend = $walker;
         if ($tagend > strlen($content)) {
             $tagend = strlen($content);
-        }
-        else {
+        } else {
             $tagend--;
             $tagstart++;
         }


### PR DESCRIPTION
## Relevant issue(s)

Splitting up PR #70. that PR is a green lint pass, but it's so big it's gonna be difficult to review.

## What does this do?
replaces:
```php
function name()
{
if true
{
}
elseif true
{
}
else
{
}
```
with 
```php
function name() {
if true {
} elseif true {
} else {
}
```


In some locations, also deleting commented-out code that's been commented out for over a decade.


## Why was this needed?

This means the code passes the linter -- and once all these lints are fixed, the php errors and warnings stand out more
