### PR TITLE
Fix display of calendar of debates

### DIFF
--- a/www/includes/easyparliament/recess.php
+++ b/www/includes/easyparliament/recess.php
@@ -268,26 +268,7 @@ $GLOBALS['recessdates'][1] = [
 ];
 
 /**
- * Function currently_in_recess() {
- * Main file which recesswatcher.py overwrites each day.
- * $h = fopen(RECESSFILE, "r");
- * $today = date("Y-m-d");
- * while ($line = fgets($h)){
- * list($name, $from, $to) = split(",", $line);
- * if ($from <= $today and $today <= $to) {
- * return [$name, trim($from), trim($to)];
- * }
- * }
- * Second manual override file.
- * $h = fopen(RECESSFILE.".extra", "r");
- * while ($line = fgets($h)){
- * list($name, $from, $to) = split(",", $line);
- * if ($from <= $today and $today <= $to) {
- * return [$name, trim($from), trim($to)];
- * }
- * }
- * return false;
- * }
+ *
  */
 function recess_prettify($day, $month, $year, $body): array {
     global $recessdates;

--- a/www/includes/easyparliament/recess.php
+++ b/www/includes/easyparliament/recess.php
@@ -289,7 +289,7 @@ $GLOBALS['recessdates'][1] = [
  * return false;
  * }
  */
-function recess_prettify($day, $month, $year, $body) {
+function recess_prettify($day, $month, $year, $body): array {
     global $recessdates;
     $dates = $recessdates[$body];
     foreach ($dates as $range) {
@@ -302,4 +302,5 @@ function recess_prettify($day, $month, $year, $body) {
             return ['recess', $range[0], $range[1]];
         }
     }
+    return [];
 }

--- a/www/includes/easyparliament/templates/html/hansard_calendar.php
+++ b/www/includes/easyparliament/templates/html/hansard_calendar.php
@@ -147,13 +147,15 @@ if (isset($data['years'])) {
                             // sittings - e.g. WH is only Tuesday-Thursday
                             if ($currentDay == $toDay) {
                                 print '<td class="on"';
-                                if ($recess[0] && $recess[0] != 1)
-                                    print ' title="' . $recess[0] . '"';
+                                if (count($recess) > 0 && $recess[0] && $recess[0] != 1) {
+                                    print ' title="' . htmlspecialchars($recess[0], ENT_QUOTES, 'UTF-8') . '"';
+                                }
                                 print '>';
-                            } elseif ($recess[0]) {
+                            } elseif (count($recess) > 0 && $recess[0]) {
                                 print '<td class="no"';
-                                if ($recess[0] != 1)
-                                    print ' title="' . $recess[0] . '"';
+                                if ($recess[0] != 1) {
+                                    print ' title="' . htmlspecialchars($recess[0], ENT_QUOTES, 'UTF-8') . '"';
+                                }
                                 print '>';
                             } else {
                                 print '<td>';

--- a/www/includes/easyparliament/templates/html/hansard_calendar.php
+++ b/www/includes/easyparliament/templates/html/hansard_calendar.php
@@ -142,7 +142,7 @@ if (isset($data['years'])) {
                                 body: 1
                             );
                             // Is this day actually Today in the real world?
-                            // If so, higlight it.
+                            // If so, highlight it.
                             // Also highlight days where there are no
                             // sittings - e.g. WH is only Tuesday-Thursday
                             if ($currentDay == $toDay) {

--- a/www/includes/easyparliament/templates/html/hansard_calendar.php
+++ b/www/includes/easyparliament/templates/html/hansard_calendar.php
@@ -134,16 +134,13 @@ if (isset($data['years'])) {
                                 <tr><?php
                             }
 
-                            if ($data['info']['major'] == 5) # NI
-                                $recess = [''];
-                            else
-                                $recess = recess_prettify(
-                                    $currentDay,
-                                    $month,
-                                    $year,
-                                    ($hansardmajors[$data['info']['major']]['location'] == 'Scotland') ? 4 : 1
-                                );
 
+                            $recess = recess_prettify(
+                                day: $currentDay,
+                                month: $month,
+                                year: $year,
+                                body: 1
+                            );
                             // Is this day actually Today in the real world?
                             // If so, higlight it.
                             // Also highlight days where there are no


### PR DESCRIPTION
## Relevant issue(s)
Calendar will not display after upgrade to php8

## What does this do?
adds types for return in recess_prettify
Checks array length before reading

## Why was this needed?
the array was null, so reading $recess[0] would error
