### PR TITLE
Declare SEARCHURL property in SEARCHLOG class

### DIFF
--- a/www/includes/easyparliament/searchlog.php
+++ b/www/includes/easyparliament/searchlog.php
@@ -25,6 +25,7 @@
 class SEARCHLOG {
 
     private $db = NULL;
+    private $SEARCHURL = NULL;
 
     /**
      *


### PR DESCRIPTION
## Relevant issue(s)
this was needed for php9 upgrade

## What does this do?
declares a member variable