### PR TITLE
Fix/db initialization

### DIFF
--- a/www/includes/easyparliament/editqueue.php
+++ b/www/includes/easyparliament/editqueue.php
@@ -46,7 +46,7 @@
  */
 class EDITQUEUE {
 
-    private $db = NULL;
+    protected $db = NULL;
 
     public $pending_count = '';
 

--- a/www/includes/easyparliament/hansardlist.php
+++ b/www/includes/easyparliament/hansardlist.php
@@ -2551,7 +2551,8 @@ class WHALLLIST extends DEBATELIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'westminhall/';
     }
 
@@ -2569,7 +2570,8 @@ class NILIST extends DEBATELIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'ni/';
     }
 
@@ -2587,7 +2589,8 @@ class SPLIST extends DEBATELIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'spor/';
     }
 
@@ -2605,7 +2608,8 @@ class SPWRANSLIST extends WRANSLIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'spwa/';
     }
 
@@ -2635,7 +2639,8 @@ class LORDSDEBATELIST extends DEBATELIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'lords/';
     }
 
@@ -2658,7 +2663,8 @@ class DEBATELIST extends HANSARDLIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'debate/';
     }
 
@@ -2903,7 +2909,8 @@ class WRANSLIST extends HANSARDLIST {
      *
      */
     public function __construct() {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'wrans/';
     }
 
@@ -3108,7 +3115,8 @@ class StandingCommittee extends DEBATELIST {
      *
      */
     public function __construct($session = '', $title = '') {
-        $this->db = new ParlDB();
+        // Sets $db.
+        parent::__construct();
         $this->gidprefix .= 'standing/';
         $this->bill_title = $title;
         $this->url = urlencode($session) . '/' . urlencode($title);

--- a/www/includes/easyparliament/user.php
+++ b/www/includes/easyparliament/user.php
@@ -64,7 +64,7 @@
  */
 class USER {
 
-    private $db = NULL;
+    protected $db = NULL;
 
     /**
      * So we have an ID for non-logged in users reporting comments etc.
@@ -944,7 +944,7 @@ class USER {
  */
 class THEUSER extends USER {
 
-    private $db = NULL;
+    // private $db = NULL;
 
     /**
      * This will become true if all goes well...
@@ -958,7 +958,8 @@ class THEUSER extends USER {
         // This function is run automatically when a THEUSER
         // object is instantiated.
 
-        $this->db = new ParlDB();
+        // Set up $this->db.
+        parent::__construct();
 
         // We look at the user's cookie and see if it's valid.
         // If so, we're going to log them in.

--- a/www/includes/easyparliament/user.php
+++ b/www/includes/easyparliament/user.php
@@ -944,8 +944,6 @@ class USER {
  */
 class THEUSER extends USER {
 
-    // private $db = NULL;
-
     /**
      * This will become true if all goes well...
      */


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/392

## What does this do?

* Builds on
  * https://github.com/openaustralia/twfy/pull/78

* Makes $db protected not private in base class,
*  removes overriding definitions in child classes,
* calls parents initializer in sub classes so functions in class and parent both work.

## Why was this needed?

To get login / user auth working

