### PR TITLE
Fixes an undeclared variable

### DIFF
--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -846,6 +846,7 @@ class PAGE {
 
         // We may want to send the user back to this current page after they've
         // joined, logged out or logged in. So we put the URL in $returl.
+        $returl = '';
         if (isset($_SERVER['REQUEST_URI'])) {
             $returl = $_SERVER['REQUEST_URI'];
         }


### PR DESCRIPTION
## What does this do?
declares a variable

## Why was this needed?
php 8 is more strict than php5

