### PR TITLE
Clean up PATH in twfy/scripts/const and allow mise local php

### DIFF
--- a/scripts/consts
+++ b/scripts/consts
@@ -1,7 +1,8 @@
 # Constants for bash scripts
 
-PATH=/usr/local/mysql/bin:/opt/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/sbin:/usr/local/bin:/usr/X11R6/bin:/home/fawkes/bin
+# Keep $PATH last so mise and other tool managers work in dev
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+export PATH
 
 # needed for correct group permissions
 umask 002
-


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/794

## What does this do?

Append rather than replace PATH in const so dev with mise works
exports PATH to make sure sub processes inherit

Removes games, fawkes's local bin, old X windows dirs, /usr/local/mysql/bin as they are not present on the server,
and if needed locally can be set in $PATH

## Why was this needed?

So I could test script/morningupdate locally

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
