### PR TITLE
Feature/788 update example dev config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ make test-coverage-docker
 
 Coverage reports are generated in `coverage/clover.xml` (for SonarCloud) and `coverage/html/` (browsable HTML).
 
-### Database credentials
+### Database credentials when using docker
 
 When running tests with the database:
 - Host: `127.0.0.1` (or `mysql` inside Docker)
@@ -137,4 +137,19 @@ To stop the Docker containers:
 
 ```bash
 docker compose down
+```
+
+### Sharing database with openaustralia-parser for development
+
+You can setup local development for both repos by:
+ 
+```bash
+# DO NOT DO THIS ON PRODUCTION!!!!
+cd ../twfy
+cp conf/general-example.local-dev conf/general
+
+cd ../openaustralia-parser # if not already there
+script/dbconsole -p < ../twfy/db/schema.sql
+bundle exec rake db:fixtures:load   # for a limited set of fixtures
+bundle exec rake db:stats # to show which tables have data
 ```

--- a/conf/general-example.local-dev
+++ b/conf/general-example.local-dev
@@ -1,0 +1,144 @@
+<?php
+// This file general-example is a template config file.
+// Edit this, and copy it to a file called general.
+
+// *******************************************************************************
+// MySQL database.
+// Use tcp
+define ("DB_HOST", "127.0.0.1");
+// Use unix socket
+// define ("DB_HOST", "localhost");
+// See README.md for different values used in docker test env
+define ("DB_USER", "openaustralia");
+define ("DB_PASSWORD", "openaustralia");
+define ("DB_NAME", "openaustralia");
+
+// *******************************************************************************
+// Domains.
+// Set this to the domain you are hosting on. If you're running locally, this will be "localhost"
+define ("DOMAIN", "openaustralia.test");
+define ("COOKIEDOMAIN", "openaustralia.test");
+
+// General 'Contact us' type email address. Point this at a real address if you
+// want the site generated email to come to you. Can be overridden for other mails below.
+
+define ("CONTACTEMAIL", "contact@openaustralia.test");
+
+// File system path to the top directory of this Theyworkforyou installation
+define ("BASEDIR",dirname(__FILE__) . "/../www/docs/");
+
+// Webserver path to 'top' directory of the site (possibly just "/"). For example,
+// if the site is at 'http://www.yourdomain.com/public/theyworkforyou',
+// this would be '/public/theyworkforyou'
+define ("WEBPATH", "/");
+
+// *******************************************************************************
+// Stop Here. In a basic developer configuration you shouldn't need to edit
+// anything below this point.
+// Feel free to have an explore if you wish though.
+// *******************************************************************************
+
+// Variables that are local to this particular set-up.
+// Put variables that are consistent across development and live servers in init.php.
+
+// If true, php errors will be displayed, not emailed to the bugs list.
+define ("DEVSITE", true);
+
+// Add this and a number to the URL (eg '?debug=1') to view debug info.
+define ("DEBUGTAG", 'debug');
+
+// Timezone (only works in PHP5)
+define ("TIMEZONE", "Australia/Sydney");
+
+// XML files and other scraped data stored as files
+define ("RAWDATA", "/var/www/openaustralia/pwdata/");
+define ('PWMEMBERS', '/var/www/openaustralia/pwdata/members/');
+
+// Path to directory where automated database backups are stored (by scripts/dumpallforbackup)
+define ("DBBACKUP", "/var/www/openaustralia/backup/");
+
+// *******************************************************************************
+// If you've unpacked the tar file normally, and set the paths correctly above,
+// you shouldn't change these.
+
+// File system path to where all the include files live.
+define ("INCLUDESPATH", BASEDIR . "/../includes/");
+
+// Web path to the directory where the site's images are kept.
+define ("IMAGEPATH", WEBPATH . "images/");
+
+// Filesystem path to where the images are kept
+define ("FILEIMAGEPATH", BASEDIR . "images/");
+
+// Path *relative* to the WEBPATH and BASEDIR where the Register of Members' Interests pdfs are stored
+define ("REGMEMPDFPATH", "regmem/scan/");
+
+// This will be included in data.php. It's an array of page/section metadata.
+define ("METADATAPATH", BASEDIR . "/../includes/easyparliament/metadata.php");
+
+// Search related. If non-empty will use XAPIAN search instead of mysql search
+define ("XAPIANDB", '');
+
+// Location of the parliamentary recess data file. You can access this remotely
+// from the main theyworkforyou site if you use
+//define ("RECESSFILE","http://www.openaustralia.org/pwdata/parl-recesses.txt");
+// AND amend your global php.ini to 'allow_url_fopen = On'
+//define ("RECESSFILE", RAWDATA . "/parl-recesses.txt");
+
+// *******************************************************************************
+// More Email addresses.
+
+// When a user reports a comment, notification is sent to this address.
+define ("REPORTLIST", CONTACTEMAIL);
+
+// All outgoing emails to users get BCC'd to this address.
+define ("BCCADDRESS", CONTACTEMAIL);
+
+// All error emails go to this address.
+define ("BUGSLIST", CONTACTEMAIL);
+
+// Email addresses that alertmailer.php sends stats to
+define('ALERT_STATS_EMAILS', CONTACTEMAIL);
+
+// Email address that alertmailer.php sends stats from
+define ('ALERT_STATS_SENDER', CONTACTEMAIL);
+
+// *******************************************************************************
+// mySociety user-tracking.
+
+// Do we add the web-bug image to each page?
+define('OPTION_TRACKING', 0);   // off by default
+
+// URL of the web-bug image.
+define('OPTION_TRACKING_URL', 'http://path/to/web/bug');
+
+// Shared secret to authenticate against the tracking service.
+define('OPTION_TRACKING_SECRET', 'really-secret-value');
+
+// For linking to HFYMP at points
+define('OPTION_AUTH_SHARED_SECRET', '');
+// define('OPTION_HEARFROMYOURMP_BASE_URL', '');
+
+// For API getGeometry call.
+// define('OPTION_MAPIT_URL', '');
+
+// For seeing if someone is in New Zealand.
+// define('OPTION_GAZE_URL', '');
+
+// mySociety debug level thing. Probably leave as 0.
+define('OPTION_PHP_DEBUG_LEVEL', 0);
+
+// *******************************************************************************
+// XML Sitemaps
+
+// Using pingmymap.com for simultaneously notifying many search engines of new xml sitemaps
+// Sign up for an account to get an API key
+define('PINGMYMAP_API_KEY', '0123456789abcdef0123456789abcdef');
+
+// *******************************************************************************
+// AddThis.com Sharing Analytics
+define('ADDTHIS_USERNAME', '');
+
+// Host to use when loading They Vote For You data
+define('PUBLICWHIP_HOST', 'https://theyvoteforyou.org.au');
+// define('DISPLAY_VOTING_DATA', false);


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?

Documents example config for sharing DB with parser

## Why was this needed?

1. README quotes a different user and password than in example config,
2. other example configs don't work with local tcp only mysql server

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
