### PR TITLE
Skip xapain indexing when XAPAINDB is not configured

### DIFF
--- a/scripts/morningupdate
+++ b/scripts/morningupdate
@@ -54,10 +54,13 @@ $VERBOSE && echo "Parsing from APH to XML and loading into the database"
 # ./xml2db.pl $CRONQUIET --recent --lordsdebates
 #./xml2db.pl $CRONQUIET --recent --ni --quiet
 
-# Update Xapan index
-$VERBOSE && echo "Xapian indexing"
-../search/index.pl $XAPIANDB sincefile $XAPIANDB/../searchdb-lastupdated $CRONQUIET_NODASH
-
+if [ -v "$XAPIANDB" ]; then
+    # Update Xapan index
+    $VERBOSE && echo "Xapian indexing"
+    ../search/index.pl "$XAPIANDB" sincefile "$XAPIANDB/../searchdb-lastupdated" "$CRONQUIET_NODASH"
+else
+    echo "SKIPPED Xapian indexing: XAPIANDB is blank"
+fi
 # Create new RSS files.
 if $VERBOSE
 then


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/794

## What does this do?

Updates morningupdate so it handles the valid situation that XAPIANDB is blank

## Why was this needed?

Because it stopped further testing

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
