### PR TITLE
Improve github action for php tests, adds dependency audit

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,27 +21,20 @@ jobs:
           extensions: mbstring, pdo, sqlite
           coverage: none # Use 'xdebug' or 'pcov' for code coverage
           tools: composer
-        env:
-          fail-fast: true
+      - name: composer install packages
+        run: composer install
+      - name: validate configuration
+        run: composer validate
       - name: Lint
         run: make lint-ci
-        env:
-          fail-fast: true
-      - name: composer
-        run: composer install
-        env:
-          fail-fast: true
-      - name: audit
-        run: composer validate
-        env:
-          fail-fast: true
       - name: phpcs
         run: make phpcs-ci
-        env:
-          fail-fast: true
+      - name: audit dependencies
+        run: composer audit
 
   test:
     runs-on: ubuntu-latest
+    needs: lint
     permissions:
       contents: read
       pull-requests: write
@@ -70,8 +63,6 @@ jobs:
           extensions: mbstring, mysqli
           coverage: xdebug
           tools: composer
-        env:
-          fail-fast: true
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Load database schema


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/809

## What does this do?

Improve github action

* Make test rely on lint passing to save running costs,
* add check of dependencies
* remove env: fail-fast as it is a strategy flag and is true by default anyway

## Why was this needed?

Noticed whilst reviewing tests results

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
