### PR TITLE
Add alert criteria sanitization and tests

### DIFF
--- a/scripts/alertmailer.php
+++ b/scripts/alertmailer.php
@@ -17,6 +17,7 @@ function mlog($message): void {
 include '../www/includes/easyparliament//init.php';
 ini_set('memory_limit', -1);
 include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once INCLUDESPATH . 'alertmailer_sanitize.php';
 
 $global_start = getmicrotime();
 $db = new ParlDB();
@@ -117,7 +118,7 @@ foreach ($alertdata as $alertitem) {
     if ($toemail && strtolower($email) >= $toemail) {
         continue;
     }
-    $criteria_raw = $alertitem['criteria'];
+    $criteria_raw = sanitize_alert_criteria($alertitem['criteria']);
     $criteria_batch = $criteria_raw . " " . $batch_query_fragment;
 
     if ($email != $current_email) {

--- a/scripts/alertmailer.php
+++ b/scripts/alertmailer.php
@@ -118,7 +118,7 @@ foreach ($alertdata as $alertitem) {
     if ($toemail && strtolower($email) >= $toemail) {
         continue;
     }
-    $criteria_raw = sanitize_alert_criteria($alertitem['criteria']);
+    $criteria_raw = sanitizeAlertCriteria($alertitem['criteria']);
     $criteria_batch = $criteria_raw . " " . $batch_query_fragment;
 
     if ($email != $current_email) {

--- a/tests/AlertMailerSanitizeTest.php
+++ b/tests/AlertMailerSanitizeTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../www/includes/alertmailer_sanitize.php';
 
 /**
- * Tests for sanitize_alert_criteria.
+ * Tests for sanitizeAlertCriteria.
  */
 class AlertMailerSanitizeTest extends TestCase {
 
@@ -14,7 +14,7 @@ class AlertMailerSanitizeTest extends TestCase {
      */
     public function test_unknown_prefix_colon_removed(): void {
         $criteria = 'Higher Education; Training: Mature Aged Workers; ANU;';
-        $result = sanitize_alert_criteria($criteria);
+        $result = sanitizeAlertCriteria($criteria);
 
         $this->assertSame('Higher Education; Training Mature Aged Workers; ANU;', $result);
     }
@@ -24,7 +24,7 @@ class AlertMailerSanitizeTest extends TestCase {
      */
     public function test_known_prefixes_preserved(): void {
         $criteria = 'speaker:10973 section:debate batch:2171 date:2026-05-10';
-        $result = sanitize_alert_criteria($criteria);
+        $result = sanitizeAlertCriteria($criteria);
 
         $this->assertSame($criteria, $result);
     }
@@ -34,7 +34,7 @@ class AlertMailerSanitizeTest extends TestCase {
      */
     public function test_known_prefix_case_insensitive(): void {
         $criteria = 'Speaker:10973 GROUPBY:day Bias:1:86400';
-        $result = sanitize_alert_criteria($criteria);
+        $result = sanitizeAlertCriteria($criteria);
 
         $this->assertSame($criteria, $result);
     }
@@ -44,7 +44,7 @@ class AlertMailerSanitizeTest extends TestCase {
      */
     public function test_url_like_tokens_not_modified(): void {
         $criteria = 'see http://example.com/path and https://example.org';
-        $result = sanitize_alert_criteria($criteria);
+        $result = sanitizeAlertCriteria($criteria);
 
         $this->assertSame($criteria, $result);
     }
@@ -54,7 +54,7 @@ class AlertMailerSanitizeTest extends TestCase {
      */
     public function test_mixed_prefixes_only_unknown_sanitized(): void {
         $criteria = 'topic:health speaker:10515 custom_field:value section:wrans';
-        $result = sanitize_alert_criteria($criteria);
+        $result = sanitizeAlertCriteria($criteria);
 
         $this->assertSame('topic health speaker:10515 custom_field value section:wrans', $result);
     }

--- a/tests/AlertMailerSanitizeTest.php
+++ b/tests/AlertMailerSanitizeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../www/includes/alertmailer_sanitize.php';
+
+/**
+ * Tests for sanitize_alert_criteria.
+ */
+class AlertMailerSanitizeTest extends TestCase {
+
+    /**
+     * Unknown prefixes should be converted to plain words.
+     */
+    public function test_unknown_prefix_colon_removed(): void {
+        $criteria = 'Higher Education; Training: Mature Aged Workers; ANU;';
+        $result = sanitize_alert_criteria($criteria);
+
+        $this->assertSame('Higher Education; Training Mature Aged Workers; ANU;', $result);
+    }
+
+    /**
+     * Known prefixes should be preserved.
+     */
+    public function test_known_prefixes_preserved(): void {
+        $criteria = 'speaker:10973 section:debate batch:2171 date:2026-05-10';
+        $result = sanitize_alert_criteria($criteria);
+
+        $this->assertSame($criteria, $result);
+    }
+
+    /**
+     * Prefix matching should be case-insensitive for allowlisted prefixes.
+     */
+    public function test_known_prefix_case_insensitive(): void {
+        $criteria = 'Speaker:10973 GROUPBY:day Bias:1:86400';
+        $result = sanitize_alert_criteria($criteria);
+
+        $this->assertSame($criteria, $result);
+    }
+
+    /**
+     * URLs should not be altered.
+     */
+    public function test_url_like_tokens_not_modified(): void {
+        $criteria = 'see http://example.com/path and https://example.org';
+        $result = sanitize_alert_criteria($criteria);
+
+        $this->assertSame($criteria, $result);
+    }
+
+    /**
+     * Unknown and known prefixes can coexist.
+     */
+    public function test_mixed_prefixes_only_unknown_sanitized(): void {
+        $criteria = 'topic:health speaker:10515 custom_field:value section:wrans';
+        $result = sanitize_alert_criteria($criteria);
+
+        $this->assertSame('topic health speaker:10515 custom_field value section:wrans', $result);
+    }
+
+}

--- a/www/includes/alertmailer_sanitize.php
+++ b/www/includes/alertmailer_sanitize.php
@@ -10,7 +10,7 @@
 /**
  * Remove unknown prefix patterns that make the search layer emit HTML warnings.
  */
-function sanitize_alert_criteria($criteria) {
+function sanitizeAlertCriteria($criteria) {
     static $known_prefixes = ['speaker', 'major', 'groupby', 'bias', 'date', 'batch', 'section'];
 
     return preg_replace_callback(

--- a/www/includes/alertmailer_sanitize.php
+++ b/www/includes/alertmailer_sanitize.php
@@ -14,7 +14,7 @@ function sanitizeAlertCriteria($criteria) {
     static $known_prefixes = ['speaker', 'major', 'groupby', 'bias', 'date', 'batch', 'section'];
 
     return preg_replace_callback(
-        '/\b([A-Za-z][A-Za-z0-9_]*)\:( ?)(?!\/\/)/',
+        '/\b([A-Za-z]\w*):( ?)(?!\/\/)/',
         function ($matches) use ($known_prefixes) {
             $prefix = strtolower($matches[1]);
             if (in_array($prefix, $known_prefixes, TRUE)) {

--- a/www/includes/alertmailer_sanitize.php
+++ b/www/includes/alertmailer_sanitize.php
@@ -1,6 +1,13 @@
 <?php
 
 /**
+ * @file
+ * alertmailer_sanitize.php
+ *
+ * Methods to sanitize input for alertmailer.
+ */
+
+/**
  * Remove unknown prefix patterns that make the search layer emit HTML warnings.
  */
 function sanitize_alert_criteria($criteria) {

--- a/www/includes/alertmailer_sanitize.php
+++ b/www/includes/alertmailer_sanitize.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Remove unknown prefix patterns that make the search layer emit HTML warnings.
+ */
+function sanitize_alert_criteria($criteria) {
+    static $known_prefixes = ['speaker', 'major', 'groupby', 'bias', 'date', 'batch', 'section'];
+
+    return preg_replace_callback(
+        '/\b([A-Za-z][A-Za-z0-9_]*)\:( ?)(?!\/\/)/',
+        function ($matches) use ($known_prefixes) {
+            $prefix = strtolower($matches[1]);
+            if (in_array($prefix, $known_prefixes, TRUE)) {
+                return $matches[0];
+            }
+            return $matches[1] . ' ';
+        },
+        $criteria
+    );
+}


### PR DESCRIPTION
## Relevant issue(s)

The alert mailer stops before completion.

## What does this do?

Sanitises the alerts that it can't parse

## Why was this needed?

something needed after the php8 upgrade
