### PR TITLE
remove duplicate github tasks

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,16 +27,6 @@ jobs:
         run: composer install
       - name: Lint
         run: make lint-php-ci
-        env:
-          fail-fast: true
-      - name: composer
-        run: composer install
-        env:
-          fail-fast: true
-      - name: audit
-        run: composer validate
-        env:
-          fail-fast: true
       - name: phpcs
         run: make phpcs-ci
       - name: audit dependencies


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/809

## What does this do?

removes duplicate github tasks

## Why was this needed?

Wasting github action resources

## Implementation/Deploy Steps (Optional)

Merge to main

## Notes to reviewer (Optional)
