### PR TITLE
Update recess_prettify to return null values instead of an empty array

### DIFF
--- a/tests/RecessTest.php
+++ b/tests/RecessTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../www/includes/easyparliament/recess.php';
+
+/**
+ * Tests for recess_prettify.
+ */
+class RecessTest extends TestCase {
+
+    /**
+     * A date inside a known recess should return recess details.
+     */
+    public function test_date_inside_recess_returns_recess_range(): void {
+        $result = recess_prettify(10, 4, 2026, 1);
+
+        $this->assertSame(['recess', '2026-04-02', '2026-05-11'], $result);
+    }
+
+    /**
+     * Recess boundaries should be inclusive.
+     */
+    public function test_recess_boundaries_are_inclusive(): void {
+        $start = recess_prettify(2, 4, 2026, 1);
+        $end = recess_prettify(11, 5, 2026, 1);
+
+        $this->assertSame(['recess', '2026-04-02', '2026-05-11'], $start);
+        $this->assertSame(['recess', '2026-04-02', '2026-05-11'], $end);
+    }
+
+    /**
+     * A date outside recess should return a fixed-shape null triplet.
+     */
+    public function test_date_outside_recess_returns_null_triplet(): void {
+        $result = recess_prettify(12, 5, 2026, 1);
+
+        $this->assertSame([NULL, NULL, NULL], $result);
+    }
+
+    /**
+     * Unknown body ids should not emit warnings and should return null triplet.
+     */
+    public function test_unknown_body_returns_null_triplet(): void {
+        $result = recess_prettify(10, 4, 2026, 999);
+
+        $this->assertSame([NULL, NULL, NULL], $result);
+    }
+
+}

--- a/www/docs/hansard/index.php
+++ b/www/docs/hansard/index.php
@@ -6,8 +6,12 @@
 
 include_once "../../includes/easyparliament/init.php";
 
+$hansardmajors = $GLOBALS['hansardmajors'] ?? [];
+
 $number_of_debates_to_show = 6;
 $number_of_wrans_to_show = 5;
+
+$nextprevdata = [];
 
 if (($date = get_http_var('d')) && preg_match('#^\d\d\d\d-\d\d-\d\d$#', $date)) {
     $this_page = 'hansard_date';
@@ -36,14 +40,6 @@ if (($date = get_http_var('d')) && preg_match('#^\d\d\d\d-\d\d-\d\d$#', $date)) 
             'title' => $title
         ];
     }
-    // $year = substr($date, 0, 4);
-    // $URL = new URL($hansardmajors[1]['page_year']);
-    // $URL->insert(array('y'=>$year));
-    // $nextprevdata['up'] = array (
-    // 'body'  => "All of $year",
-    // 'title' => '',
-    // 'url'   => $URL->generate()
-    // );
     $DATA->set_page_metadata($this_page, 'nextprev', $nextprevdata);
     $PAGE->page_start();
     $PAGE->stripe_start();

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -271,7 +271,7 @@ class PAGE {
 
             foreach ($links as $n => $type) {
                 if (isset($nextprev[$type]) && isset($nextprev[$type]['listurl'])) {
-
+                    $linktitle = '';
                     if (isset($nextprev[$type]['body'])) {
                         $linktitle = htmlentities(trim_characters($nextprev[$type]['body'], 0, 40));
                         if (
@@ -406,7 +406,7 @@ class PAGE {
 
             foreach ($links as $n => $type) {
                 if (isset($nextprev[$type]) && isset($nextprev[$type]['listurl'])) {
-
+                    $linktitle = '';
                     if (isset($nextprev[$type]['body'])) {
                         $linktitle = htmlentities(trim_characters($nextprev[$type]['body'], 0, 40));
                         if (
@@ -1465,6 +1465,7 @@ class PAGE {
         print $desc;
         if ($member['other_parties'] && $member['party'] != 'Speaker' && $member['party'] != 'Deputy-Speaker' && $member['party'] != 'President' && $member['party'] != 'Deputy-President') {
             print "<li>Changed party ";
+            $out = [];
             foreach ($member['other_parties'] as $r) {
                 $out[] = 'from ' . $r['from'] . ' on ' . format_date($r['date'], SHORTDATEFORMAT);
             }

--- a/www/includes/easyparliament/recess.php
+++ b/www/includes/easyparliament/recess.php
@@ -270,9 +270,9 @@ $GLOBALS['recessdates'][1] = [
 /**
  *
  */
-function recess_prettify($day, $month, $year, $body): array {
+function recess_prettify(int $day, int $month, int $year, int $body): array {
     global $recessdates;
-    $dates = $recessdates[$body];
+    $dates = $recessdates[$body] ?? [];
     foreach ($dates as $range) {
         [$from_year, $from_month, $from_day] = array_map('intval', explode('-', $range[0]));
         [$to_year, $to_month, $to_day] = array_map('intval', explode('-', $range[1]));
@@ -283,5 +283,5 @@ function recess_prettify($day, $month, $year, $body): array {
             return ['recess', $range[0], $range[1]];
         }
     }
-    return [];
+    return [NULL, NULL, NULL];
 }


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?
Fixes errors on the front page of openaustralia.org.au
