### PR TITLE
Initialize $hansardmajors variable from global scope

### DIFF
--- a/www/docs/hansard/index.php
+++ b/www/docs/hansard/index.php
@@ -6,6 +6,8 @@
 
 include_once "../../includes/easyparliament/init.php";
 
+$hansardmajors = $GLOBALS['hansardmajors'] ?? [];
+
 $number_of_debates_to_show = 6;
 $number_of_wrans_to_show = 5;
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

This was missing in the php 5 to php 8 upgrade

## What does this do?

Pulls in the `$hansardmajors` from global variables.

## Why was this needed?

php8 changed how globals work

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
