### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/mp page

### DIFF
--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -27,14 +27,14 @@
  * Either way, we print the forms.
  */
 
-include_once __DIR__ . "/../../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
 include_once __DIR__ . "/../../includes/postcode.php";
 include_once __DIR__ . "/../../includes/technorati.php";
-include_once __DIR__ . '/../api/api_getGeometry.php';
-include_once __DIR__ . '/../api/api_getConstituencies.php';
+include_once __DIR__ . "/../api/api_getGeometry.php";
+include_once __DIR__ . "/../api/api_getConstituencies.php";
 
 twfy_debug_timestamp("after includes");
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/828

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/mp page

## Why was this needed?

Page was returning 500 error

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
