### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/individual pages

### DIFF
--- a/www/docs/404.php
+++ b/www/docs/404.php
@@ -5,8 +5,8 @@
  */
 
 $this_page = '404';
-include_once dirname(__FILE__) . '/../includes/easyparliament/init.php';
-include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once __DIR__ . '/../includes/easyparliament/init.php';
+include_once __DIR__ . '/../includes/easyparliament/member.php';
 
 $PAGE->page_start();
 $PAGE->stripe_start();

--- a/www/docs/addlink/index.php
+++ b/www/docs/addlink/index.php
@@ -4,9 +4,9 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
-include_once INCLUDESPATH . "easyparliament/glossarylist.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossarylist.php";
 
 
 $this_page = "glossary_addlink";

--- a/www/docs/addterm/index.php
+++ b/www/docs/addterm/index.php
@@ -4,9 +4,9 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
-include_once INCLUDESPATH . "easyparliament/glossarylist.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossarylist.php";
 
 
 // $this_page = "glossary_addterm";

--- a/www/docs/contact/index.php
+++ b/www/docs/contact/index.php
@@ -6,13 +6,13 @@
 
 $this_page = "contact";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/contact.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/contact.php';
 
 $PAGE->stripe_end();
 

--- a/www/docs/email/index.php
+++ b/www/docs/email/index.php
@@ -6,8 +6,8 @@
 
 $this_page = "emailfriend";
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . '/../../includes/easyparliament/member.php';
 
 $PAGE->page_start();
 

--- a/www/docs/getinvolved/index.php
+++ b/www/docs/getinvolved/index.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $this_page = "getinvolved";
 
@@ -12,7 +12,7 @@ $PAGE->page_start();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/getinvolved.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/getinvolved.php';
 
 $PAGE->stripe_end();
 

--- a/www/docs/glossary/index.php
+++ b/www/docs/glossary/index.php
@@ -10,8 +10,8 @@ if ($term) {
     $this_page = "glossary";
 }
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 
 $args = [

--- a/www/docs/hansard/index.php
+++ b/www/docs/hansard/index.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $hansardmajors = $GLOBALS['hansardmajors'] ?? [];
 
@@ -43,7 +43,7 @@ if (($date = get_http_var('d')) && preg_match('#^\d\d\d\d-\d\d-\d\d$#', $date)) 
     $DATA->set_page_metadata($this_page, 'nextprev', $nextprevdata);
     $PAGE->page_start();
     $PAGE->stripe_start();
-    include_once INCLUDESPATH . 'easyparliament/recess.php';
+    include_once __DIR__ . '/../../includes/easyparliament/recess.php';
     $time = strtotime($date);
     $dayofweek = date('w', $time);
     $recess = recess_prettify(date('j', $time), date('n', $time), date('Y', $time), 1);

--- a/www/docs/hansardbugs/index.php
+++ b/www/docs/hansardbugs/index.php
@@ -5,7 +5,7 @@
  */
 
 $this_page = 'hansard_bugs';
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 $DATA->set_page_metadata($this_page, 'heading', 'Official Hansard problems');
 
 $PAGE->page_start();

--- a/www/docs/help/index.php
+++ b/www/docs/help/index.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $this_page = "help";
 
@@ -12,7 +12,7 @@ $PAGE->page_start();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/help.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/help.php';
 
 $PAGE->stripe_end();
 

--- a/www/docs/help/linktous/index.php
+++ b/www/docs/help/linktous/index.php
@@ -12,7 +12,7 @@ $PAGE->page_start();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/linktous.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/linktous.php';
 
 $PAGE->stripe_end();
 

--- a/www/docs/help/mobile.php
+++ b/www/docs/help/mobile.php
@@ -6,7 +6,7 @@
 
 $_SERVER['DEVICE_TYPE'] = "mobile";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $this_page = "help";
 
@@ -14,7 +14,7 @@ $PAGE->page_start_mobile();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/help.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/help.php';
 
 // $PAGE->stripe_end();
 

--- a/www/docs/houserules/index.php
+++ b/www/docs/houserules/index.php
@@ -6,13 +6,13 @@
 
 $this_page = "houserules";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/houserules.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/houserules.php';
 
 $PAGE->stripe_end();
 

--- a/www/docs/how/index.php
+++ b/www/docs/how/index.php
@@ -6,7 +6,7 @@
 
 $this_page = "how";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 

--- a/www/docs/index-election.php
+++ b/www/docs/index-election.php
@@ -6,8 +6,8 @@
 
 $this_page = "home";
 
-include_once "../includes/easyparliament/init.php";
-include_once "../includes/easyparliament/member.php";
+include_once __DIR__ . "/../includes/easyparliament/init.php";
+include_once __DIR__ . "/../includes/easyparliament/member.php";
 
 $PAGE->page_start();
 

--- a/www/docs/jargon/index.php
+++ b/www/docs/jargon/index.php
@@ -6,7 +6,7 @@
 
 $this_page = "glossary";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 

--- a/www/docs/mlas/index.php
+++ b/www/docs/mlas/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/people.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/people.php";
 
 $this_page = 'mlas';
 

--- a/www/docs/msps/index.php
+++ b/www/docs/msps/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/people.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/people.php";
 
 $this_page = 'msps';
 

--- a/www/docs/ni/index.php
+++ b/www/docs/ni/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // For displaying all the NIA debates on a day, or a single debate.
 

--- a/www/docs/parsing/index.php
+++ b/www/docs/parsing/index.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 $DATA->set_page_metadata($this_page, 'heading', 'Parsing status page');
 $PAGE->page_start();
 $PAGE->stripe_start();

--- a/www/docs/pbc/index.php
+++ b/www/docs/pbc/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once "../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // For displaying Standing Committee debates. I know they're Public Bill
 // Committees now, but I've called them standing committees everywhere.

--- a/www/docs/privacy/index.php
+++ b/www/docs/privacy/index.php
@@ -6,7 +6,7 @@
 
 $this_page = "privacy";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 

--- a/www/docs/regmem/index.php
+++ b/www/docs/regmem/index.php
@@ -14,7 +14,7 @@ while ($file = readdir($dh)) {
 }
 rsort($files);
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 $PAGE->page_start();
 ?>
 <style type="text/css">

--- a/www/docs/rss/index.php
+++ b/www/docs/rss/index.php
@@ -4,9 +4,9 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
-include_once INCLUDESPATH . "postcode.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . "/../../includes/postcode.php";
 
 $pc = get_http_var('pc');
 $pc = preg_replace('#[^a-z0-9 ]#i', '', $pc);

--- a/www/docs/senators/index.php
+++ b/www/docs/senators/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/people.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/people.php";
 
 $this_page = 'peers';
 

--- a/www/docs/skin/index.php
+++ b/www/docs/skin/index.php
@@ -6,7 +6,7 @@
 
 $this_page = "skin";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 

--- a/www/docs/sp/index.php
+++ b/www/docs/sp/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // For displaying all the SP debates on a day, or a single debate.
 

--- a/www/docs/spwrans/index.php
+++ b/www/docs/spwrans/index.php
@@ -4,9 +4,9 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 // For displaying written answers.
 

--- a/www/docs/user/confirm/index.php
+++ b/www/docs/user/confirm/index.php
@@ -16,7 +16,7 @@
 
 
 include_once "../../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 
 if (get_http_var('welcome') == 't') {

--- a/www/docs/user/index.php
+++ b/www/docs/user/index.php
@@ -36,8 +36,8 @@ display_user()  Displays a user's details.
  */
 
 
-include_once "../../includes/easyparliament/init.php";
-include_once "../../includes/easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 // Which page we're on all depends on the value of the "pg" variable...
 switch (get_http_var("pg")) {

--- a/www/docs/vote/index.php
+++ b/www/docs/vote/index.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $db = new ParlDB();
 

--- a/www/docs/whall/index.php
+++ b/www/docs/whall/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once "../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 
 // For displaying all the WH debates on a day, or a single WH debate.

--- a/www/docs/wms/index.php
+++ b/www/docs/wms/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once "../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 
 // For displaying all the WMS on a day, or a single WMS.

--- a/www/docs/wrans/index.php
+++ b/www/docs/wrans/index.php
@@ -4,9 +4,9 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 // For displaying written answers.
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/individual pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
