### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/search pages

### DIFF
--- a/www/docs/search/index.php
+++ b/www/docs/search/index.php
@@ -1,11 +1,11 @@
 <?php
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
-include_once INCLUDESPATH . "postcode.php";
+include_once __DIR__ . "/../../includes/postcode.php";
 
 if (get_http_var('s') != '' || get_http_var('pid') != '') {
 
@@ -184,7 +184,7 @@ if (get_http_var('s') != '' || get_http_var('pid') != '') {
     $this_page = 'search_help';
     $PAGE->page_start();
     $PAGE->stripe_start();
-    include INCLUDESPATH . 'easyparliament/staticpages/search_help.php';
+    include __DIR__ . '/../../includes/easyparliament/staticpages/search_help.php';
 }
 
 $PAGE->stripe_end([

--- a/www/docs/search/mobile.php
+++ b/www/docs/search/mobile.php
@@ -1,12 +1,12 @@
 <?php
 $_SERVER['DEVICE_TYPE'] = "mobile";
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
-include_once INCLUDESPATH . "postcode.php";
+include_once __DIR__ . "/../../includes/postcode.php";
 
 if (get_http_var('s') != '' || get_http_var('pid') != '') {
     // We're searching for something.
@@ -181,7 +181,7 @@ if (get_http_var('s') != '' || get_http_var('pid') != '') {
     $this_page = 'search_help';
     $PAGE->page_start_mobile();
     $PAGE->stripe_start();
-    include INCLUDESPATH . 'easyparliament/staticpages/search_help.php';
+    include __DIR__ . '/../../includes/easyparliament/staticpages/search_help.php';
 }
 
 

--- a/www/docs/search/rss/index.php
+++ b/www/docs/search/rss/index.php
@@ -2,11 +2,11 @@
 # vim:sw=4:ts=4:et:nowrap
 
 include_once "../../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
-include_once INCLUDESPATH . "postcode.php";
+include_once __DIR__ . "/../../includes/postcode.php";
 
 if (get_http_var('s') != '' or get_http_var('maj') != '' or get_http_var('pid') != '') {
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/search pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
