### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in index/mobile pairs of pages

### DIFF
--- a/www/docs/index.php
+++ b/www/docs/index.php
@@ -6,8 +6,8 @@
 
 $this_page = "home";
 
-include_once "../includes/easyparliament/init.php";
-include_once "../includes/easyparliament/member.php";
+include_once __DIR__ . "/../includes/easyparliament/init.php";
+include_once __DIR__ . "/../includes/easyparliament/member.php";
 
 $PAGE->page_start();
 

--- a/www/docs/mobile.php
+++ b/www/docs/mobile.php
@@ -8,8 +8,8 @@ $_SERVER['DEVICE_TYPE'] = "mobile";
 
 $this_page = "home";
 
-include_once "../includes/easyparliament/init.php";
-include_once "../includes/easyparliament/member.php";
+include_once __DIR__ . "/../includes/easyparliament/init.php";
+include_once __DIR__ . "/../includes/easyparliament/member.php";
 
 $PAGE->page_start_mobile();
 

--- a/www/docs/mp/mobile.php
+++ b/www/docs/mp/mobile.php
@@ -32,14 +32,14 @@ Either way, we print the forms.
 
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
-include_once INCLUDESPATH . "postcode.php";
-include_once INCLUDESPATH . 'technorati.php';
-include_once '../api/api_getGeometry.php';
-include_once '../api/api_getConstituencies.php';
+include_once __DIR__ . "/../../includes/postcode.php";
+include_once __DIR__ . '/../../includes/technorati.php';
+include_once __DIR__ . '/../api/api_getGeometry.php';
+include_once __DIR__ . '/../api/api_getConstituencies.php';
 
 twfy_debug_timestamp("after includes");
 

--- a/www/docs/mps/index.php
+++ b/www/docs/mps/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/people.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/people.php";
 
 $this_page = 'mps';
 if (get_http_var('c4')) {

--- a/www/docs/senate/index.php
+++ b/www/docs/senate/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // For displaying all the Lords debates on a day, or a single debate.
 

--- a/www/docs/senate/mobile.php
+++ b/www/docs/senate/mobile.php
@@ -6,8 +6,8 @@
 
 $_SERVER['DEVICE_TYPE'] = "mobile";
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 // For displaying all the Lords debates on a day, or a single debate.
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in index/mobile pairs of pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
