### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/gadget pages

### DIFF
--- a/www/docs/gadget/dat.php
+++ b/www/docs/gadget/dat.php
@@ -6,7 +6,7 @@
  */
 
 include_once 'min-init.php';
-include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once __DIR__ . '/../../includes/easyparliament/member.php';
 include_once '../api/api_functions.php';
 
 $pid = $_GET['pid'];

--- a/www/docs/gadget/index.php
+++ b/www/docs/gadget/index.php
@@ -6,7 +6,7 @@
 
 $this_page = 'gadget';
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 $PAGE->stripe_start();

--- a/www/docs/gadget/min-init.php
+++ b/www/docs/gadget/min-init.php
@@ -4,8 +4,8 @@ error_reporting(E_ALL);
 ini_set('memory_limit', 16 * 1024 * 1024);
 
 include_once "../../../conf/general";
-include_once INCLUDESPATH . "utility.php";
-include_once INCLUDESPATH . "mysql.php";
+include_once __DIR__ . "/../../includes/utility.php";
+include_once __DIR__ . "/../../includes/mysql.php";
 
 /**
  *

--- a/www/docs/gadget/pc.php
+++ b/www/docs/gadget/pc.php
@@ -5,7 +5,7 @@
  */
 
 include_once 'min-init.php';
-include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once __DIR__ . '/../../includes/easyparliament/member.php';
 
 $pc = $_GET['pc'];
 $pc = preg_replace('#[^a-z0-9 ]#i', '', $pc);


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/gadget pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
