### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in easyparliament files

### DIFF
--- a/www/includes/easyparliament/commentlist.php
+++ b/www/includes/easyparliament/commentlist.php
@@ -27,7 +27,7 @@ of comment data and display directly (used for previewing user input).
 
  */
 
-include_once INCLUDESPATH . 'dbtypes.php';
+include_once __DIR__ . '/../dbtypes.php';
 
 /**
  *
@@ -104,7 +104,7 @@ class COMMENTLIST {
      *
      */
     public function render($data, $format = 'html', $template = 'comments') {
-        include INCLUDESPATH . "easyparliament/templates/$format/$template.php";
+        include __DIR__ . "/../easyparliament/templates/$format/$template.php";
     }
 
     /**

--- a/www/includes/easyparliament/glossary.php
+++ b/www/includes/easyparliament/glossary.php
@@ -21,9 +21,9 @@ As they are being approved/declined they can be modified (spelling etc...).
  */
 
 // This handles basic insertion and approval functions for all epobjects.
-include_once INCLUDESPATH . "easyparliament/editqueue.php";
-include_once INCLUDESPATH . "easyparliament/searchengine.php";
-include_once INCLUDESPATH . "wikipedia.php";
+include_once __DIR__ . "/../easyparliament/editqueue.php";
+include_once __DIR__ . "/../easyparliament/searchengine.php";
+include_once __DIR__ . "/../wikipedia.php";
 
 /**
  *

--- a/www/includes/easyparliament/glossarylist.php
+++ b/www/includes/easyparliament/glossarylist.php
@@ -16,7 +16,7 @@ class GLOSSARYLIST {
             $format = 'html';
         }
 
-        include INCLUDESPATH . "easyparliament/templates/$format/$template.php";
+        include __DIR__ . "/../easyparliament/templates/$format/$template.php";
 
     }
 

--- a/www/includes/easyparliament/hansardlist.php
+++ b/www/includes/easyparliament/hansardlist.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once INCLUDESPATH . "easyparliament/searchengine.php";
-include_once INCLUDESPATH . "easyparliament/searchlog.php";
+include_once __DIR__ . "/searchengine.php";
+include_once __DIR__ . "/searchlog.php";
 
 /**
  * The HANSARDLIST class and its children, DEBATELIST and WRANSLIST, display data about
@@ -195,8 +195,8 @@ class HANSARDLIST {
             return $data;
         }
 
-        $standard_template = INCLUDESPATH . "easyparliament/templates/$format/hansard_$view.php";
-        $mobile_template = INCLUDESPATH . "easyparliament/templates/$format/hansard_{$view}_mobile.php";
+        $standard_template = __DIR__ . "/../easyparliament/templates/$format/hansard_$view.php";
+        $mobile_template = __DIR__ . "/../easyparliament/templates/$format/hansard_{$view}_mobile.php";
 
         // Not every possible view here has a mobile version. So, only use the mobile version template if it exists.
         if ($mobile && file_exists($mobile_template)) {
@@ -3130,7 +3130,7 @@ class StandingCommittee extends DEBATELIST {
      *
      */
     public function _get_committee($bill_id) {
-        include_once INCLUDESPATH . "easyparliament/member.php";
+        include_once __DIR__ . "/../easyparliament/member.php";
         $q = $this->db->query('select count(*) as c from hansard where major=6 and minor=' .
             $this->db->escape($bill_id) . ' and htype=10');
         $sittings = $q->field(0, 'c');

--- a/www/includes/easyparliament/init.php
+++ b/www/includes/easyparliament/init.php
@@ -43,7 +43,7 @@ define('CONSTITUENCY_COOKIE', 'constituency');
  ********************************************************************************/
 
 include_once dirname(__FILE__) . '/../../../conf/general';
-include_once INCLUDESPATH . 'utility.php';
+include_once __DIR__ . '/../utility.php';
 twfy_debug_timestamp("after including utility.php");
 
 // Set the default timezone.
@@ -62,8 +62,8 @@ if (!isset($_SERVER['WINDIR'])) {
     define('STARTTIMES', $rusage['ru_stime.tv_sec'] * 1000000 + $rusage['ru_stime.tv_usec']);
     define('STARTTIMEU', $rusage['ru_utime.tv_sec'] * 1000000 + $rusage['ru_utime.tv_usec']);
 }
-include_once INCLUDESPATH . "data.php";
-include_once INCLUDESPATH . "mysql.php";
+include_once __DIR__ . "/../data.php";
+include_once __DIR__ . "/../mysql.php";
 
 /**
  *
@@ -79,17 +79,17 @@ class ParlDB extends MySQL {
 
 }
 
-include_once INCLUDESPATH . "url.php";
-include_once INCLUDESPATH . "lib_filter.php";
-include_once INCLUDESPATH . "easyparliament/skin.php";
-include_once INCLUDESPATH . "easyparliament/user.php";
-include_once INCLUDESPATH . "easyparliament/page.php";
-include_once INCLUDESPATH . "easyparliament/hansardlist.php";
-include_once INCLUDESPATH . "easyparliament/commentlist.php";
-include_once INCLUDESPATH . "easyparliament/comment.php";
-include_once INCLUDESPATH . "easyparliament/trackback.php";
+include_once __DIR__ . "/../url.php";
+include_once __DIR__ . "/../lib_filter.php";
+include_once __DIR__ . "/../easyparliament/skin.php";
+include_once __DIR__ . "/../easyparliament/user.php";
+include_once __DIR__ . "/../easyparliament/page.php";
+include_once __DIR__ . "/../easyparliament/hansardlist.php";
+include_once __DIR__ . "/../easyparliament/commentlist.php";
+include_once __DIR__ . "/../easyparliament/comment.php";
+include_once __DIR__ . "/../easyparliament/trackback.php";
 
 // Added in as new module by Richard Allan MP.
-include_once INCLUDESPATH . "easyparliament/alert.php";
+include_once __DIR__ . "/../easyparliament/alert.php";
 
 twfy_debug_timestamp("at end of init.php");

--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once INCLUDESPATH . "postcode.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../postcode.php";
+include_once __DIR__ . "/glossary.php";
 
 /**
  *

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -5,10 +5,10 @@
  */
 
 if (defined('OPTION_TRACKING') && OPTION_TRACKING) {
-    require_once INCLUDESPATH . '../../../phplib/tracking.php';
+    require_once __DIR__ . '/../../../../phplib/tracking.php';
 }
 
-include_once INCLUDESPATH . '../../../phplib/gaze.php';
+include_once __DIR__ . '/../../../../phplib/gaze.php';
 include_once __DIR__ . '/member.php';
 include_once __DIR__ . '/../request.php';
 
@@ -1107,7 +1107,7 @@ class PAGE {
     public function include_sidebar_template($sidebarname) {
         global $this_page, $DATA;
 
-        $sidebarpath = INCLUDESPATH . 'easyparliament/sidebars/' . $sidebarname . '.php';
+        $sidebarpath = __DIR__ . '/../easyparliament/sidebars/' . $sidebarname . '.php';
 
         if (file_exists($sidebarpath)) {
             include $sidebarpath;
@@ -2394,7 +2394,7 @@ class PAGE {
      */
     public function recess_message() {
         // Returns a message if parliament is currently in recess.
-        include_once INCLUDESPATH . "easyparliament/recess.php";
+        include_once __DIR__ . "/../easyparliament/recess.php";
         $message = '';
         [$name, $from, $to] = recess_prettify(date('j'), date('n'), date('Y'), 1);
         if ($name) {

--- a/www/includes/easyparliament/people.php
+++ b/www/includes/easyparliament/people.php
@@ -57,7 +57,7 @@ class PEOPLE {
             return $data;
         }
 
-        include INCLUDESPATH . "easyparliament/templates/{$format}/people_{$view}.php";
+        include __DIR__ . "/../easyparliament/templates/{$format}/people_{$view}.php";
         return TRUE;
 
     }

--- a/www/includes/easyparliament/searchengine.php
+++ b/www/includes/easyparliament/searchengine.php
@@ -11,7 +11,7 @@ francis@flourish.org
 
 Example usage:
 
-include_once INCLUDESPATH."easyparliament/searchengine.php";
+include_once __DIR__ . "/../easyparliament/searchengine.php";
 
 $searchengine = new SEARCHENGINE($searchstring);
 $description = $searchengine->query_description();
@@ -29,7 +29,7 @@ $extract = $searchengine->highlight($extract);
 
  */
 
-include_once INCLUDESPATH . 'dbtypes.php';
+include_once __DIR__ . '/../dbtypes.php';
 if (defined('XAPIANDB') && XAPIANDB) {
     if (file_exists('/usr/local/share/php5/xapian.php')) {
         include_once '/usr/local/share/php5/xapian.php';

--- a/www/includes/easyparliament/sidebars/search.php
+++ b/www/includes/easyparliament/sidebars/search.php
@@ -10,6 +10,6 @@ $this->block_start([
     'title' => "Search Tips"
 ]);
 
-include INCLUDESPATH . 'easyparliament/staticpages/search_help.php';
+include __DIR__ . '/../staticpages/search_help.php';
 
 $this->block_end();

--- a/www/includes/easyparliament/templates/html/hansard_calendar.php
+++ b/www/includes/easyparliament/templates/html/hansard_calendar.php
@@ -23,7 +23,7 @@
 // $data['info'] may have 'onday', a 'yyyy-mm-dd' date which indicates
 // which date will be highlighted (otherwise, today is).
 
-include_once INCLUDESPATH . "easyparliament/recess.php";
+include_once __DIR__ . "/../../../easyparliament/recess.php";
 global $PAGE, $DATA, $this_page, $hansardmajors;
 
 twfy_debug("TEMPLATE", "hansard_calendar.php");

--- a/www/includes/easyparliament/templates/html/hansard_gid.php
+++ b/www/includes/easyparliament/templates/html/hansard_gid.php
@@ -11,9 +11,8 @@
 
 global $PAGE, $this_page, $GLOSSARY, $hansardmajors;
 
-include_once INCLUDESPATH . "easyparliament/searchengine.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
-
+include_once __DIR__ . "/../../../easyparliament/searchengine.php";
+include_once __DIR__ . "/../../../easyparliament/member.php";
 
 twfy_debug("TEMPLATE", "hansard_gid.php");
 

--- a/www/includes/easyparliament/templates/html/hansard_gid_mobile.php
+++ b/www/includes/easyparliament/templates/html/hansard_gid_mobile.php
@@ -11,8 +11,8 @@
 
 global $PAGE, $this_page, $GLOSSARY, $hansardmajors;
 
-include_once INCLUDESPATH . "easyparliament/searchengine.php";
-include_once INCLUDESPATH . "easyparliament/member.php";
+include_once __DIR__ . "/../../../easyparliament/searchengine.php";
+include_once __DIR__ . "/../../../easyparliament/member.php";
 
 
 twfy_debug("TEMPLATE", "hansard_gid.php");

--- a/www/includes/easyparliament/trackback.php
+++ b/www/includes/easyparliament/trackback.php
@@ -117,7 +117,7 @@ class TRACKBACK {
         // We currently only have one kind of trackback template, so
         // we're ignoring $view here I'm afraid...
 
-        include INCLUDESPATH . "easyparliament/templates/{$format}/trackbacks.php";
+        include __DIR__ . "/../easyparliament/templates/{$format}/trackbacks.php";
 
     }
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in easyparliament files

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
