### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/departments pages

### DIFF
--- a/www/docs/departments/index.php
+++ b/www/docs/departments/index.php
@@ -4,7 +4,7 @@
  * @file
  * Nasty way of implementing "by department" stuff with the current schema .*/
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $dept = get_http_var('dept');
 $PAGE->page_start();

--- a/www/docs/departments/questions.php
+++ b/www/docs/departments/questions.php
@@ -4,7 +4,7 @@
  * @file
  * Nasty way of implementing "by department" stuff with the current schema .*/
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $dept = get_http_var('dept');
 $PAGE->page_start();

--- a/www/docs/departments/statements.php
+++ b/www/docs/departments/statements.php
@@ -4,7 +4,7 @@
  * @file
  * Nasty way of implementing "by department" stuff with the current schema .*/
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $dept = get_http_var('dept');
 $PAGE->page_start();


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

## Why was this needed?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/departments pages

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
