### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/api pages

### DIFF
--- a/www/docs/api/api_getHansard.php
+++ b/www/docs/api/api_getHansard.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once INCLUDESPATH . "easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 /**
  *

--- a/www/docs/api/api_getMP.php
+++ b/www/docs/api/api_getMP.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once __DIR__ . '/../../includes/easyparliament/member.php';
 
 /**
  *

--- a/www/docs/api/key.php
+++ b/www/docs/api/key.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once '../../includes/easyparliament/init.php';
-include_once INCLUDESPATH . 'postcode.php';
+include_once __DIR__ . '/../../includes/easyparliament/init.php';
+include_once __DIR__ . '/../../includes/postcode.php';
 include_once __DIR__ . '/api_functions.php';
 include_once __DIR__ . '/../../../../phplib/auth.php';
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/api pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
