### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/alert pages

### DIFF
--- a/www/docs/alert/authed.php
+++ b/www/docs/alert/authed.php
@@ -13,7 +13,7 @@
 //
 // $Id: authed.php,v 1.1 2006/05/26 08:44:46 matthew Exp $.
 
-include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . '/../../includes/easyparliament/init.php';
 include_once __DIR__ . '/../../../../phplib/auth.php';
 
 header("Content-Type: text/plain");

--- a/www/docs/alert/authed.php
+++ b/www/docs/alert/authed.php
@@ -13,8 +13,8 @@
 //
 // $Id: authed.php,v 1.1 2006/05/26 08:44:46 matthew Exp $.
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . '../../../phplib/auth.php';
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . '/../../../../phplib/auth.php';
 
 header("Content-Type: text/plain");
 

--- a/www/docs/alert/confirm/index.php
+++ b/www/docs/alert/confirm/index.php
@@ -32,9 +32,9 @@
 
 // INITIALISATION.
 
-include_once "../../../includes/easyparliament/init.php";
-include_once "../../../includes/easyparliament/member.php";
-include_once INCLUDESPATH . '../../../phplib/crosssell.php';
+include_once __DIR__ . "/../../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../../includes/easyparliament/member.php";
+include_once __DIR__ . '/../../../../../phplib/crosssell.php';
 
 // Instantiate an instance of ALERT.
 

--- a/www/docs/alert/confirm/index.php
+++ b/www/docs/alert/confirm/index.php
@@ -32,8 +32,8 @@
 
 // INITIALISATION.
 
-include_once __DIR__ . "/../../../includes/easyparliament/init.php";
-include_once __DIR__ . "/../../../includes/easyparliament/member.php";
+include_once __DIR__ . '/../../../includes/easyparliament/init.php';
+include_once __DIR__ . '/../../../includes/easyparliament/member.php';
 include_once __DIR__ . '/../../../../../phplib/crosssell.php';
 
 // Instantiate an instance of ALERT.

--- a/www/docs/alert/index.php
+++ b/www/docs/alert/index.php
@@ -15,11 +15,11 @@
  * set_criteria() Sets search criteria from information in MP and Keyword fields.
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once "../../includes/easyparliament/people.php";
-include_once "../../includes/easyparliament/member.php";
-include_once INCLUDESPATH . '../../../phplib/auth.php';
-include_once INCLUDESPATH . '../../../phplib/crosssell.php';
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/people.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . '/../../../../phplib/auth.php';
+include_once __DIR__ . '/../../../../phplib/crosssell.php';
 
 $this_page = "alert";
 

--- a/www/docs/alert/index.php
+++ b/www/docs/alert/index.php
@@ -15,9 +15,9 @@
  * set_criteria() Sets search criteria from information in MP and Keyword fields.
  */
 
-include_once __DIR__ . "/../../includes/easyparliament/init.php";
-include_once __DIR__ . "/../../includes/easyparliament/people.php";
-include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . '/../../includes/easyparliament/init.php';
+include_once __DIR__ . '/../../includes/easyparliament/people.php';
+include_once __DIR__ . '/../../includes/easyparliament/member.php';
 include_once __DIR__ . '/../../../../phplib/auth.php';
 include_once __DIR__ . '/../../../../phplib/crosssell.php';
 

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -27,13 +27,13 @@
  * Either way, we print the forms.
  */
 
-include_once __DIR__ . "/../../includes/easyparliament/init.php";
-include_once __DIR__ . "/../../includes/easyparliament/member.php";
+include_once __DIR__ . '/../../includes/easyparliament/init.php';
+include_once __DIR__ . '/../../includes/easyparliament/member.php';
 
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
-include_once __DIR__ . "/../../includes/postcode.php";
-include_once __DIR__ . "/../api/api_getGeometry.php";
-include_once __DIR__ . "/../api/api_getConstituencies.php";
+include_once __DIR__ . '/../../includes/postcode.php';
+include_once __DIR__ . '/../api/api_getGeometry.php';
+include_once __DIR__ . '/../api/api_getConstituencies.php';
 
 twfy_debug_timestamp("after includes");
 

--- a/www/docs/trackback/index.php
+++ b/www/docs/trackback/index.php
@@ -5,8 +5,8 @@
  * This code based on stuff from http://wordpress.org/
  */
 
-include_once __DIR__ . "/../../includes/easyparliament/init.php";
-include_once __DIR__ . "/../../includes/request.php";
+include_once __DIR__ . '/../../includes/easyparliament/init.php';
+include_once __DIR__ . '/../../includes/request.php';
 
 $this_page = 'trackback';
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/alert pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
