### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/about pages

### DIFF
--- a/www/docs/about/index.php
+++ b/www/docs/about/index.php
@@ -6,13 +6,13 @@
 
 $this_page = "about";
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 
 $PAGE->page_start();
 
 $PAGE->stripe_start();
 
-include INCLUDESPATH . 'easyparliament/staticpages/about.php';
+include __DIR__ . '/../../includes/easyparliament/staticpages/about.php';
 
 $PAGE->stripe_end();
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/about pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
