### PR TITLE
Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/admin pages

### DIFF
--- a/www/docs/admin/alert_stats.php
+++ b/www/docs/admin/alert_stats.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once "../../includes/easyparliament/member.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 $this_page = "alert_stats";
 

--- a/www/docs/admin/alerts.php
+++ b/www/docs/admin/alerts.php
@@ -4,10 +4,10 @@
  * @file
  */
 
-include_once '../../includes/easyparliament/init.php';
-include_once INCLUDESPATH . 'easyparliament/commentreportlist.php';
-include_once INCLUDESPATH . 'easyparliament/searchengine.php';
-include_once INCLUDESPATH . 'easyparliament/member.php';
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
+include_once __DIR__ . "/../../includes/easyparliament/searchengine.php";
+include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
 $this_page = 'admin_alerts';
 

--- a/www/docs/admin/badusers.php
+++ b/www/docs/admin/badusers.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/commentreportlist.php";
+include_once __DIR__ . "/../../includes//easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
 $this_page = "admin_badusers";
 
@@ -20,13 +20,13 @@ $PAGE->stripe_start();
 <?php
 
 // Get a list of the users who have the most deleted comments.
-$q = $db->query("SELECT COUNT(*) AS deletedcount, 
+$q = $db->query("SELECT COUNT(*) AS deletedcount,
 						u.user_id,
 						u.firstname,
 						u.lastname,
 						u.email
 				FROM 	comments c, users u
-				WHERE 	c.visible = 0 
+				WHERE 	c.visible = 0
 				AND		c.user_id = u.user_id
 				GROUP BY user_id
 				ORDER BY deletedcount DESC");

--- a/www/docs/admin/comments.php
+++ b/www/docs/admin/comments.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/commentreportlist.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
 $this_page = "admin_comments";
 

--- a/www/docs/admin/failedsearches.php
+++ b/www/docs/admin/failedsearches.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/searchlog.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/searchlog.php";
 
 $this_page = "admin_failedsearches";
 

--- a/www/docs/admin/glossary.php
+++ b/www/docs/admin/glossary.php
@@ -5,9 +5,9 @@
  * Some sketchy crap for displaying pending glossary additions.
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/editqueue.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/editqueue.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 $this_page = "admin_glossary";
 

--- a/www/docs/admin/glossary_pending.php
+++ b/www/docs/admin/glossary_pending.php
@@ -5,9 +5,9 @@
  * Some sketchy crap for displaying pending glossary additions.
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/editqueue.php";
-include_once INCLUDESPATH . "easyparliament/glossary.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/editqueue.php";
+include_once __DIR__ . "/../../includes/easyparliament/glossary.php";
 
 $this_page = "admin_glossary_pending";
 

--- a/www/docs/admin/index.php
+++ b/www/docs/admin/index.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/commentreportlist.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
 $this_page = "admin_home";
 

--- a/www/docs/admin/popularsearches.php
+++ b/www/docs/admin/popularsearches.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/searchlog.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/searchlog.php";
 
 $this_page = "admin_popularsearches";
 

--- a/www/docs/admin/report.php
+++ b/www/docs/admin/report.php
@@ -9,8 +9,8 @@
 // Pass it a GET string like ?rid=37&cid=54
 // where rid is a report_id and cid is a comment_id.
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/commentreport.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreport.php";
 
 $this_page = "admin_commentreport";
 
@@ -135,9 +135,9 @@ function view($REPORT, $COMMENT, $FORMURL) {
     $REPORT->display();
 
     ?>
-    
+
     <p><strong>Do you wish to delete the comment?</strong></p>
-    
+
     <form action="<?php echo $FORMURL->generate(); ?>" method="post">
         <p><input type="submit" name="yes" value=" Yes "> &nbsp;
         <input type="submit" name="no" value=" No ">
@@ -158,7 +158,7 @@ function get_template_contents($template) {
     // so may be scope for rationalising...
     global $PAGE;
 
-    $filename = INCLUDESPATH . "easyparliament/templates/emails/" . $template . ".txt";
+    $filename = include_once __DIR__ . "/../../includes/easyparliament/templates/emails/" . $template . ".txt";
 
     if (!file_exists($filename)) {
         $PAGE->error_message("Sorry, we could not find the email template.");
@@ -190,7 +190,7 @@ function prepare_emails_for_deleting($REPORT, $COMMENT, $FORMURL) {
         <p><strong>You've chosen to delete this comment.</strong> You can now send an email to both the person who posted the comment, and the person who made the report. Uncheck a box to prevent an email from being sent. The comment will not be deleted until you click the button below.</p>
 
         <form action="<?php echo $FORMURL->generate(); ?>" method="post">
-            
+
             <p><strong><input type="checkbox" name="sendtocommenter" value="true" checked id="sendtocommenter"> <label for="sendtocommenter">Send this email to the person who posted the comment:</label></strong></p>
 
 <!--            <p class="email-template"><?php echo $commentermail; ?></p> -->
@@ -224,14 +224,14 @@ function prepare_emails_for_not_deleting($REPORT, $COMMENT, $FORMURL) {
 
     ?>
         <p><strong>You have chosen not to delete this comment.</strong> You can now send an email to the person who made the report (uncheck the box to send no email). The report will not be resolved until you click the button below.</p>
-        
+
         <form action="<?php echo $FORMURL->generate(); ?>" method="post">
             <p>&nbsp;<br><strong><input type="checkbox" name="sendtoreporter" value="true" checked id="sendtoreporter"> <label for="sendtoreporter">Send this email to the person who reported the comment:</label></strong></p>
 
             <p class="email-template"><?php echo $reportermail; ?></p>
-            
+
             <p>Enter a reason to replace {REASON}: <input type="text" name="declinedreason" size="40"></p>
-            
+
             <p><input type="submit" name="resolve" value=" Resolve this report ">
             <input type="hidden" name="deletecomment" value="false">
             <input type="hidden" name="rid" value="<?php echo htmlentities($REPORT->report_id()); ?>">

--- a/www/docs/admin/reports.php
+++ b/www/docs/admin/reports.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/commentreportlist.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
 $this_page = "admin_commentreports";
 

--- a/www/docs/admin/searchlogs.php
+++ b/www/docs/admin/searchlogs.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/searchlog.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/searchlog.php";
 
 $this_page = "admin_searchlogs";
 

--- a/www/docs/admin/statistics.php
+++ b/www/docs/admin/statistics.php
@@ -4,7 +4,7 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
 $this_page = "admin_statistics";
 
 $db = new ParlDB();

--- a/www/docs/admin/trackbacks.php
+++ b/www/docs/admin/trackbacks.php
@@ -4,8 +4,8 @@
  * @file
  */
 
-include_once "../../includes/easyparliament/init.php";
-include_once INCLUDESPATH . "easyparliament/commentreportlist.php";
+include_once __DIR__ . "/../../includes/easyparliament/init.php";
+include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
 $this_page = "admin_trackbacks";
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/829

## What does this do?

Replace usage of INCLUDESPATH with __DIR__ anchored paths in www/docs/admin pages

## Why was this needed?

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
