### PR TITLE
Use https://www.zend.com not http

### DIFF
--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -3087,7 +3087,7 @@ class PAGE {
      *
      */
     public function display_calendar_month($month, $year, $dateArray, $page) {
-        // From http://www.zend.com/zend/trick/tricks-Oct-2002.php
+        // From https://www.zend.com/zend/trick/tricks-Oct-2002.php
         // Adjusted for style, putting Monday first, and the URL of the page linked to.
 
         // Used in templates/html/hansard_calendar.php.

--- a/www/includes/easyparliament/templates/html/hansard_calendar.php
+++ b/www/includes/easyparliament/templates/html/hansard_calendar.php
@@ -35,7 +35,7 @@ if (isset($data['years'])) {
             // $month and $year are integers.
             // $dates is an array of dates that should be links in this month.
 
-            // From http://www.zend.com/zend/trick/tricks-Oct-2002.php
+            // From https://www.zend.com/zend/trick/tricks-Oct-2002.php
             // Adjusted for style, putting Monday first, and the URL of the page linked to.
 
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.zend.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
