### PR TITLE
Use https://www.wordpress.org not http

### DIFF
--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -250,7 +250,7 @@ function api_front_page($error = '') {
 
     <ul>
         <li><a href="http://code.google.com/p/poli-press/">PoliPress</a> is a <a
-                href="http://www.wordpress.org/">WordPress</a> plugin that lets you quote members of parliament and search
+                href="https://www.wordpress.org/">WordPress</a> plugin that lets you quote members of parliament and search
             the Australian Hansard from within your WordPress blog.</li>
         <li><a href="https://github.com/henare/oa4wp/">OpenAustralia for WordPress</a> is another WordPress plugin. It
             displays your MP's most recent speeches on your blog.</li>

--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -76,7 +76,7 @@ Many of you may have been in the same situation as this - you're out having a qu
 
 A feature that we added to the site recently, created by yours truly, is the ability to share speeches on social networks. You may have noticed that there is a "Share This" link next to each speech listed on OpenAustralia. Simply hover over that link and select the social network you want to share the speech on and start a discussion with your friends.
 
-If you have a <a href="http://www.wordpress.org/">Wordpress blog</a> that you host yourself you'll be interested in a plugin that was developed by <a href="http://www.sherifmansour.com/">Sherif Mansour</a> at our recent Hackfest in Sydney called <a href="http://code.google.com/p/poli-press/">PoliPress</a>. Using this plugin you can import speeches from OpenAustralia right into your own blog to discuss them or comment on them.
+If you have a <a href="https://www.wordpress.org/">Wordpress blog</a> that you host yourself you'll be interested in a plugin that was developed by <a href="http://www.sherifmansour.com/">Sherif Mansour</a> at our recent Hackfest in Sydney called <a href="http://code.google.com/p/poli-press/">PoliPress</a>. Using this plugin you can import speeches from OpenAustralia right into your own blog to discuss them or comment on them.
 
 We hope you enjoy the new features and if you have any ideas for what you'd like to see on OpenAustralia, <a href="mailto:contact@openaustralia.org">please get in touch</a>!
 EOT


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.wordpress.org not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
