### PR TITLE
Use https://www.w3.org not http

### DIFF
--- a/scripts/mprss.php
+++ b/scripts/mprss.php
@@ -85,7 +85,7 @@ for ($personrow = 0; $personrow < $q->rows(); $personrow++) {
     $rsstext = '<?xml version="1.0" encoding="iso-8859-1"?>
 <rdf:RDF
   xmlns:dc="http://purl.org/dc/elements/1.1/"
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns="http://purl.org/rss/1.0/"
   xmlns:content="http://purl.org/rss/1.0/modules/content/">
 		

--- a/www/docs/news/rdf.php
+++ b/www/docs/news/rdf.php
@@ -9,7 +9,7 @@ include dirname(__FILE__) . '/../../includes/easyparliament/init.php';
 require_once "editme.php";
 print '<?xml version="1.0" encoding="iso-8859-1"?>' ?>
 
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"
+<rdf:RDF xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"
     xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:admin="http://webns.net/mvcb/"
     xmlns:cc="http://web.resource.org/cc/" xmlns="http://purl.org/rss/1.0/">
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -300,7 +300,7 @@ class PAGE {
         }
 
         ?>
-        <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+        <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
         <html>
 
         <head>
@@ -436,7 +436,7 @@ class PAGE {
         }
 
         ?>
-        <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+        <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
         <html>
 
         <head>
@@ -2430,7 +2430,7 @@ class PAGE {
         */
         ?>
                 <!--
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+<rdf:RDF xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
         xmlns:dc="http://purl.org/dc/elements/1.1/"
         xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/">
 <rdf:Description


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.w3.org not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
