### PR TITLE
Use https://www.theyworkforyou.com not http

### DIFF
--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -121,7 +121,7 @@
             things which we don't count yet, and some which we never could. Even when we
             do, a count doesn't measure the quality of a Representative's contribution.</p>
 
-        <p>On the UK site <a href="http://www.theyworkforyou.com">TheyWorkForYou</a>, they used to publish absolute
+        <p>On the UK site <a href="https://www.theyworkforyou.com">TheyWorkForYou</a>, they used to publish absolute
             rankings of, for
             instance, the most verbose MPs. Then, they were hearing from real MP's researchers who
             admitted to tabling questions to increase their boss' rankings. So, TheyWorkForYou


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.theyworkforyou.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
