### PR TITLE
Remove NZ check and http://www.theyworkforyou.co.nz link

### DIFF
--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -497,9 +497,6 @@ class PAGE {
                 twfy_debug("PAGE", "This page: $this_page");
 
                 print "\t<a name=\"top\"></a>\n\n";
-                if (defined('OPTION_GAZE_URL') && OPTION_GAZE_URL && (gaze_get_country_from_ip(ip_address()) == 'NZ' || get_http_var('nz'))) {
-                    print '<p align="center"><strong>New!</strong> You\'re in New Zealand, so check out <a href="https://www.theyworkforyou.co.nz">OpenAustralia.co.nz</a></p>';
-                }
 
                 $this->title_bar();
 
@@ -522,9 +519,6 @@ class PAGE {
                         twfy_debug("PAGE", "This page: $this_page");
 
                         print "\t<a name=\"top\"></a>\n\n";
-                        if (defined('OPTION_GAZE_URL') && OPTION_GAZE_URL && (gaze_get_country_from_ip(ip_address()) == 'NZ' || get_http_var('nz'))) {
-                            print '<p align="center"><strong>New!</strong> You\'re in New Zealand, so check out <a href="https://www.theyworkforyou.co.nz">OpenAustralia.co.nz</a></p>';
-                        }
 
                         $this->title_bar_mobile();
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -498,7 +498,7 @@ class PAGE {
 
                 print "\t<a name=\"top\"></a>\n\n";
                 if (defined('OPTION_GAZE_URL') && OPTION_GAZE_URL && (gaze_get_country_from_ip(ip_address()) == 'NZ' || get_http_var('nz'))) {
-                    print '<p align="center"><strong>New!</strong> You\'re in New Zealand, so check out <a href="http://www.theyworkforyou.co.nz">OpenAustralia.co.nz</a></p>';
+                    print '<p align="center"><strong>New!</strong> You\'re in New Zealand, so check out <a href="https://www.theyworkforyou.co.nz">OpenAustralia.co.nz</a></p>';
                 }
 
                 $this->title_bar();
@@ -523,7 +523,7 @@ class PAGE {
 
                         print "\t<a name=\"top\"></a>\n\n";
                         if (defined('OPTION_GAZE_URL') && OPTION_GAZE_URL && (gaze_get_country_from_ip(ip_address()) == 'NZ' || get_http_var('nz'))) {
-                            print '<p align="center"><strong>New!</strong> You\'re in New Zealand, so check out <a href="http://www.theyworkforyou.co.nz">OpenAustralia.co.nz</a></p>';
+                            print '<p align="center"><strong>New!</strong> You\'re in New Zealand, so check out <a href="https://www.theyworkforyou.co.nz">OpenAustralia.co.nz</a></p>';
                         }
 
                         $this->title_bar_mobile();


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.theyworkforyou.co.nz not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
