### PR TITLE
Use https://www.smh.com.au not http

### DIFF
--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -172,7 +172,7 @@
                 href="http://www.aph.gov.au/Parliamentary_Business/Committees/House_of_Representatives_Committees?url=pmi/index.htm">Standing
                 Committee of Privileges and Members' Interests</a>.</p>
 
-        <p>You might also be interested in <a href="http://www.smh.com.au/national/political-interests">a searchable
+        <p>You might also be interested in <a href="https://www.smh.com.au/national/political-interests">a searchable
                 database</a> of the register, compiled by SMH. Note that this was created in 2012 and may not be up to
             date.</p>
     </dd>

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -172,7 +172,7 @@
                 href="http://www.aph.gov.au/Parliamentary_Business/Committees/House_of_Representatives_Committees?url=pmi/index.htm">Standing
                 Committee of Privileges and Members' Interests</a>.</p>
 
-        <p>You might also be interested in <a href="https://www.smh.com.au/national/political-interests">a searchable
+        <p>You might also be interested in <a href="https://www.smh.com.au/politics">a searchable
                 database</a> of the register, compiled by SMH. Note that this was created in 2012 and may not be up to
             date.</p>
     </dd>


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.smh.com.au not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
