### PR TITLE
Use https://www.purecaffeine.com not http

### DIFF
--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -176,7 +176,7 @@ EOT
     5 => [
         'A new look OpenAustralia',
         <<<EOT
-OpenAustralia has a lovely and sleek new look courtesy of <a href="http://www.purecaffeine.com/">Nathanael Boehm</a>.
+OpenAustralia has a lovely and sleek new look courtesy of <a href="https://www.purecaffeine.com/">Nathanael Boehm</a>.
 
 We're always interested in feedback, so let us know what you think by <a href="mailto:contact@openaustralia.org">emailing us</a> at the usual place. Enjoy!
 EOT


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.purecaffeine.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
