### PR TITLE
Use https://www.php.net not http

### DIFF
--- a/www/includes/easyparliament/init.php
+++ b/www/includes/easyparliament/init.php
@@ -19,7 +19,7 @@ define("ALLOWTRACKBACKS", TRUE);
 
 // These variables are so we can keep date/time formats consistent across the site
 // and change them easily.
-// Formats here: http://www.php.net/manual/en/function.date.php
+// Formats here: https://www.php.net/manual/en/function.date.php
 // Monday, 31 December 2003.
 define("LONGERDATEFORMAT", "l, j F Y");
 // 31 December 2003


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.php.net not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
