### PR TITLE
Use https://www.openaustraliafoundation.org.au not http

### DIFF
--- a/emailalertstemplate/edm.html
+++ b/emailalertstemplate/edm.html
@@ -593,7 +593,7 @@
 				<tr>
 					<td class="container-padding" bgcolor="#f4e859" style="background-color: #f4e859; padding-left: 10px; padding-right: 10px; font-size: 10px; line-height: 20px; font-family: Helvetica, sans-serif; color: #333; text-align: left;" align="left">
 						<br>
-						<div style="line-height: 24px;"><a href="https://www.openaustraliafoundation.org.au/" target="_blank" style="color: #333; font-family: 'museo slab', sans-serif; font-size: 14px; font-weight: bold; letter-spacing: -1px; text-decoration: none;" class="oaflink">the OpenAustralia Foundation</a> <span style="color: #744D29; font-family: 'Georgia', sans-serif; font-size: 14px; font-style: italic;">&mdash; Transforming democracy in Australia</span></div>
+						<div style="line-height: 24px;"><a href="https://www.oaf.org.au/" target="_blank" style="color: #333; font-family: 'museo slab', sans-serif; font-size: 14px; font-weight: bold; letter-spacing: -1px; text-decoration: none;" class="oaflink">the OpenAustralia Foundation</a> <span style="color: #744D29; font-family: 'Georgia', sans-serif; font-size: 14px; font-style: italic;">&mdash; Transforming democracy in Australia</span></div>
 						<br>
 					</td>
 				</tr>

--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -152,7 +152,7 @@ EOT
         <<<EOT
 We've completely rewritten the engine that drives OpenAustralia. We didn't want to, the government (website) made us do it. No really. For a bit of background read our blog post <a href="https://blog.openaustralia.org/2008/10/13/why-is-openaustralia-not-getting-updated/">"Why is OpenAustralia not getting updated?"</a>.
 
-The outage of new update has only been over the last couple of weeks (from 13 Oct) and this all fixed now. I did quit a paying job to make it happen, so if that makes you feel like <a href="https://www.openaustraliafoundation.org.au/donate/">donating some money to us</a>, please go ahead!
+The outage of new update has only been over the last couple of weeks (from 13 Oct) and this all fixed now. I did quit a paying job to make it happen, so if that makes you feel like <a href="https://www.oaf.org.au/donate/">donating some money to us</a>, please go ahead!
 
 Catch up on the debates that happened while we were down. As of next week when parliament resumes, email updates will be back in action too.
 EOT

--- a/www/includes/easyparliament/sidebars/whatisthissite.php
+++ b/www/includes/easyparliament/sidebars/whatisthissite.php
@@ -18,7 +18,7 @@ $helpurl = $URL->generate();
         <img src="<?php echo IMAGEPATH . "donate_greenL.png" ?>" width="108" height="43" border="0" align="right"
             hspace="4" vspace="5" alt="Donate"></a>
     <a href="<?php echo $abouturl; ?>" title="link to About Us page">OpenAustralia.org</a> is a
-    non-partisan website run by a charity, the <a href="http://www.openaustraliafoundation.org.au">OpenAustralia
+    non-partisan website run by a charity, the <a href="https://www.openaustraliafoundation.org.au">OpenAustralia
         Foundation</a>. It aims to make it easy for people to keep tabs on their
     representatives in Parliament.
 </p>

--- a/www/includes/easyparliament/sidebars/whatisthissite.php
+++ b/www/includes/easyparliament/sidebars/whatisthissite.php
@@ -18,7 +18,7 @@ $helpurl = $URL->generate();
         <img src="<?php echo IMAGEPATH . "donate_greenL.png" ?>" width="108" height="43" border="0" align="right"
             hspace="4" vspace="5" alt="Donate"></a>
     <a href="<?php echo $abouturl; ?>" title="link to About Us page">OpenAustralia.org</a> is a
-    non-partisan website run by a charity, the <a href="https://www.openaustraliafoundation.org.au">OpenAustralia
+    non-partisan website run by a charity, the <a href="https://www.oaf.org.au">OpenAustralia
         Foundation</a>. It aims to make it easy for people to keep tabs on their
     representatives in Parliament.
 </p>

--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -9,7 +9,7 @@
 
 <h3>Who runs this site?</h3>
 
-<p>OpenAustralia is a website run by a charity, the <a href="http://www.openaustraliafoundation.org.au">OpenAustralia
+<p>OpenAustralia is a website run by a charity, the <a href="https://www.openaustraliafoundation.org.au">OpenAustralia
         Foundation</a>.
     OpenAustralia Foundation is a public digital online library.
     We owe a great debt to a UK charity, mySociety, which built <a

--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -9,7 +9,7 @@
 
 <h3>Who runs this site?</h3>
 
-<p>OpenAustralia is a website run by a charity, the <a href="https://www.openaustraliafoundation.org.au">OpenAustralia
+<p>OpenAustralia is a website run by a charity, the <a href="https://www.oaf.org.au">OpenAustralia
         Foundation</a>.
     OpenAustralia Foundation is a public digital online library.
     We owe a great debt to a UK charity, mySociety, which built <a

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -180,7 +180,7 @@
     <dt><a name="regmem-links"></a>Why are there two Register of Interests links for some MPs?</dt>
     <dd>
         <p>In early 2009, OpenAustralia.org was <a
-                href="https://www.openaustraliafoundation.org.au/2009/01/05/the-register-of-senators-interests-is-now-online-2/">the
+                href="https://www.oaf.org.au/2009/01/05/the-register-of-senators-interests-is-now-online-2/">the
                 first to publish</a> the important Register of Interests online. We're happy to say that Australian
             Parliament House now publishes this register online themselves.</p>
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.openaustraliafoundation.org.au not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report
## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
