### PR TITLE
Use https://www.mysociety.org not http

### DIFF
--- a/www/docs/alert/authed.php
+++ b/www/docs/alert/authed.php
@@ -9,7 +9,7 @@
 // Uses shared secret for authentication.
 //
 // Copyright (c) 2006 UK Citizens Online Democracy. All rights reserved.
-// Email: matthew@mysociety.org. WWW: http://www.mysociety.org
+// Email: matthew@mysociety.org. WWW: https://www.mysociety.org
 //
 // $Id: authed.php,v 1.1 2006/05/26 08:44:46 matthew Exp $.
 


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.mysociety.org not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
