### PR TITLE
Use https://www.iamcal.com not http

### DIFF
--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -825,7 +825,7 @@ function send_email($to, $subject, $message, $bulk = FALSE) {
 
 //
 // Cal's functions from
-// http://www.iamcal.com/publish/article.php?id=13
+// https://www.iamcal.com/publish/article.php?id=13
 
 /**
  * Call this with a key name to get a GET or POST variable.


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.iamcal.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
