### PR TITLE
Use https://www.henaredegan.com not http

### DIFF
--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -233,7 +233,7 @@ function api_front_page($error = '') {
         <li><a href="source/oaapi.phps">PHP source</a> and <a href="source/test.phps">example</a> (thanks to Mark Kinkade
             for adapting <a href="https://github.com/rubenarakelyan/twfyapi/">Ruben Arakelyan's TWFY bindings</a>)</li>
         <li><a href="https://github.com/henare/openaustralia-api/">Ruby</a>, by <a href="http://www.acooper.org/">Alex
-                Cooper</a>, updated by <a href="http://www.henaredegan.com/">Henare Degan</a></li>
+                Cooper</a>, updated by <a href="https://www.henaredegan.com/">Henare Degan</a></li>
         <li><a href="https://github.com/rubenarakelyan/twfyapi/">PHP &amp; ASP.NET</a>, by <a href="http://ra.me.uk/">Ruben
                 Arakelyan</a></li>
         <li><a href="https://pypi.python.org/pypi/openaustralia">Python</a>, by Chris Nilsson</li>


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.henaredegan.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
