### PR TITLE
Remove facebook.com group reference as we no longer use it

### DIFF
--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -88,7 +88,7 @@ EOT
     11 => [
         'Our new home on Facebook',
         <<<EOT
-If you're a user of Facebook, come and visit <a href="http://www.facebook.com/pages/OpenAustralia/59877428354">our new home on Facebook</a> and invite your friends along. Do your bit by letting even more people know about OpenAustralia.org.
+If you're a user of Facebook, come and visit <a href="https://www.facebook.com/pages/OpenAustralia/59877428354">our new home on Facebook</a> and invite your friends along. Do your bit by letting even more people know about OpenAustralia.org.
 
 Also, you can talk amongst your fellow OpenAustralia fans, leave comments, post links and all the usual stuff.
 EOT

--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -85,18 +85,6 @@ EOT
         'Henare'
     ],
 
-    11 => [
-        'Our new home on Facebook',
-        <<<EOT
-If you're a user of Facebook, come and visit <a href="https://www.facebook.com/pages/OpenAustralia/59877428354">our new home on Facebook</a> and invite your friends along. Do your bit by letting even more people know about OpenAustralia.org.
-
-Also, you can talk amongst your fellow OpenAustralia fans, leave comments, post links and all the usual stuff.
-EOT
-,
-        '2009-05-12 16:30:00',
-        'Matthew'
-    ],
-
     10 => [
         'Opening up the procedures of Parliament',
         <<<EOT


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Remove facebook.com group reference

## Why was this needed?

We no longer use a FB group

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
