### PR TITLE
Use https://www.channel4.com not http

### DIFF
--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -552,10 +552,10 @@ class PAGE {
 
         if ($this_page != 'home') {
             if (get_http_var('c4')) {
-                $HOMEURL = 'http://www.channel4.com/news/microsites/E/election2005/';
+                $HOMEURL = 'https://www.channel4.com/news/microsites/E/election2005/';
                 $HOMETITLE = 'To Channel 4\'s main election site';
             } elseif (get_http_var('c4x')) {
-                $HOMEURL = 'http://www.channel4.com/life/microsites/E/elexion/';
+                $HOMEURL = 'https://www.channel4.com/life/microsites/E/elexion/';
                 $HOMETITLE = 'To Channel 4\'s main election site';
             } else {
                 $HOMEURL = new URL('home');


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.channel4.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
