### PR TITLE
Use https://www.aph.gov.au not http

### DIFF
--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -113,7 +113,7 @@ Now, the Register of Interests is available for all sitting Senators and Represe
 
 See, for instance, the <a href="/mp/kevin_rudd/griffith#register">Register of Interests for the Prime Minister, Kevin Rudd</a>, available at the bottom of his page. (<a href="/regmem/scan/register_interests_10552.pdf">direct link</a>)
 
-This latest addition was largely made possible by the generous help of volunteer <a href="http://shiny.thorne.id.au/">Stephen Thorne</a> at <a href="http://netboxblue.com/">Netbox Blue</a> who scanned the 1500 pages of the Register of Members' Interests and <a href="https://www.aph.gov.au/HOUSE/dept/bios/bw.htm">Bernard Wright</a>, the Registrar of Members' Interests, for providing us with the hardcopy material.
+This latest addition was largely made possible by the generous help of volunteer Stephen Thorne at Netbox Blue who scanned the 1500 pages of the Register of Members' Interests and <a href="https://adb.anu.edu.au/biography/wright-bernard-clive-28242">Bernard Wright</a>, the Registrar of Members' Interests, for providing us with the hardcopy material.
 
 EOT
 ,

--- a/www/docs/news/editme.php
+++ b/www/docs/news/editme.php
@@ -113,7 +113,7 @@ Now, the Register of Interests is available for all sitting Senators and Represe
 
 See, for instance, the <a href="/mp/kevin_rudd/griffith#register">Register of Interests for the Prime Minister, Kevin Rudd</a>, available at the bottom of his page. (<a href="/regmem/scan/register_interests_10552.pdf">direct link</a>)
 
-This latest addition was largely made possible by the generous help of volunteer <a href="http://shiny.thorne.id.au/">Stephen Thorne</a> at <a href="http://netboxblue.com/">Netbox Blue</a> who scanned the 1500 pages of the Register of Members' Interests and <a href="http://www.aph.gov.au/HOUSE/dept/bios/bw.htm">Bernard Wright</a>, the Registrar of Members' Interests, for providing us with the hardcopy material.
+This latest addition was largely made possible by the generous help of volunteer <a href="http://shiny.thorne.id.au/">Stephen Thorne</a> at <a href="http://netboxblue.com/">Netbox Blue</a> who scanned the 1500 pages of the Register of Members' Interests and <a href="https://www.aph.gov.au/HOUSE/dept/bios/bw.htm">Bernard Wright</a>, the Registrar of Members' Interests, for providing us with the hardcopy material.
 
 EOT
 ,

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -172,8 +172,8 @@
                 href="https://www.aph.gov.au/Parliamentary_Business/Committees/House_of_Representatives_Committees?url=pmi/index.htm">Standing
                 Committee of Privileges and Members' Interests</a>.</p>
 
-        <p>You might also be interested in <a href="https://www.smh.com.au/politics">a searchable
-                database</a> of the register, compiled by SMH. Note that this was created in 2012 and may not be up to
+        <p>You might also be interested in <a href="https://www.smh.com.au/politics">a searchable database</a>
+            of the register, compiled by SMH. Note that this was created in 2012 and may not be up to
             date.</p>
     </dd>
 

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -47,7 +47,7 @@
             and the divisions (voting) and so far goes back to the beginning of 2006. It also does not include
             committees. Think of what we've done
             thus far as a mere taster of what could be possible.
-            If you want the complete, definitive record, go to the <a href="http://www.aph.gov.au/"
+            If you want the complete, definitive record, go to the <a href="https://www.aph.gov.au/"
                 title="Link to Australian Parliament website">Australian Parliament</a> site, and you might be able to
             find what you want.</p>
     </dd>
@@ -167,9 +167,9 @@
             the things that have been considered to be a potential influence on their behaviour in Parliament.</p>
 
         <p>Find out more at the <a
-                href="http://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Senators_Interests">Senate Standing
+                href="https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Senators_Interests">Senate Standing
                 Committee of Senators' Interests</a> and the <a
-                href="http://www.aph.gov.au/Parliamentary_Business/Committees/House_of_Representatives_Committees?url=pmi/index.htm">Standing
+                href="https://www.aph.gov.au/Parliamentary_Business/Committees/House_of_Representatives_Committees?url=pmi/index.htm">Standing
                 Committee of Privileges and Members' Interests</a>.</p>
 
         <p>You might also be interested in <a href="https://www.smh.com.au/politics">a searchable


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.aph.gov.au not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
