### PR TITLE
Use https://www.ag.gov.au not http

### DIFF
--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -17,7 +17,7 @@
 </p>
 
 <p>The Australian Hansard is
-    <a href="https://www.ag.gov.au/cca">Copyright Commonwealth of Australia</a>,
+    <a href="https://www.aph.gov.au/Help/Disclaimer_Privacy_Copyright">Copyright Commonwealth of Australia</a>,
     and is used with permission. Images of politicians are <a href="https://www.aph.gov.au/Help/Disclaimer_Privacy_Copyright">Copyright Commonwealth of
         Australia</a> and administered by <a href="mailto:auspic@aph.gov.au">AUSPIC</a>.
 </p>

--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -18,7 +18,7 @@
 
 <p>The Australian Hansard is
     <a href="https://www.ag.gov.au/cca">Copyright Commonwealth of Australia</a>,
-    and is used with permission. Images of politicians are <a href="https://www.ag.gov.au/cca">Copyright Commonwealth of
+    and is used with permission. Images of politicians are <a href="https://www.aph.gov.au/Help/Disclaimer_Privacy_Copyright">Copyright Commonwealth of
         Australia</a> and administered by <a href="mailto:auspic@aph.gov.au">AUSPIC</a>.
 </p>
 <p>If you're technically minded, we make all the

--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -17,8 +17,8 @@
 </p>
 
 <p>The Australian Hansard is
-    <a href="http://www.ag.gov.au/cca">Copyright Commonwealth of Australia</a>,
-    and is used with permission. Images of politicians are <a href="http://www.ag.gov.au/cca">Copyright Commonwealth of
+    <a href="https://www.ag.gov.au/cca">Copyright Commonwealth of Australia</a>,
+    and is used with permission. Images of politicians are <a href="https://www.ag.gov.au/cca">Copyright Commonwealth of
         Australia</a> and administered by <a href="mailto:auspic@aph.gov.au">AUSPIC</a>.
 </p>
 <p>If you're technically minded, we make all the


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://www.ag.gov.au not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
