### PR TITLE
Use https://uk.php.net not http

### DIFF
--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -194,7 +194,7 @@ function vardump($blah) {
 }
 
 /**
- * Pretty prints the backtrace, copied from http://uk.php.net/manual/en/function.debug-backtrace.php.
+ * Pretty prints the backtrace, copied from https://uk.php.net/manual/en/function.debug-backtrace.php.
  */
 function adodb_backtrace($print = TRUE) {
     $s = '';


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://uk.php.net not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
