### PR TITLE
Use https://software.openaustralia.org not http

### DIFF
--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1255,7 +1255,7 @@ class PAGE {
             }
         }
         $links[] = '<a href="' . WEBPATH . 'api/">API</a> / <a href="http://data.openaustralia.org">XML</a>';
-        $links[] = '<a href="http://software.openaustralia.org">Source code</a>';
+        $links[] = '<a href="https://software.openaustralia.org">Source code</a>';
 
         $qs = $_SERVER['QUERY_STRING'];
         if (preg_match('/.*show_pc.*/i', $qs)) {

--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -22,7 +22,7 @@
         Australia</a> and administered by <a href="mailto:auspic@aph.gov.au">AUSPIC</a>.
 </p>
 <p>If you're technically minded, we make all the
-    <a href="http://software.openaustralia.org/">OpenAustralia source code</a>
+    <a href="https://software.openaustralia.org/">OpenAustralia source code</a>
     freely available. Do let us know if you want to help!
 </p>
 

--- a/www/includes/easyparliament/staticpages/getinvolved.php
+++ b/www/includes/easyparliament/staticpages/getinvolved.php
@@ -22,7 +22,7 @@
 
     <dt><a name="knowsphp"></a>I know PHP and HTML and stuff like that.</dt>
     <dd>
-        <p>Great, check out <a href="http://software.openaustralia.org/">web application source<a>.</p>
+        <p>Great, check out <a href="https://software.openaustralia.org/">web application source<a>.</p>
     </dd>
     <!-- end old faq entry -->
 </dl>
@@ -32,7 +32,7 @@
 
     <dt><a name="knowsruby"></a>I know Ruby and I can write parsers, can I help you crunch the source data?</dt>
     <dd>
-        <p>You sure can. Check out the <a href="http://software.openaustralia.org/">parser source code</a> and let us
+        <p>You sure can. Check out the <a href="https://software.openaustralia.org/">parser source code</a> and let us
             know what you want to add.</p>
     </dd>
     <!-- end old faq entry -->


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://software.openaustralia.org not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
