### PR TITLE
Use https://groups.google.com not http

### DIFF
--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -243,7 +243,7 @@ function api_front_page($error = '') {
         the language bindings developed for the <a href="http://theyworkforyou.com/api">TheyWorkForYou API</a> won't
         directly work with the OpenAustralia API. If anyone wishes to adapt them or write new bindings, please
         do so, let us know and we'll link to it here. You might want to <a
-            href="http://groups.google.com/group/openaustralia-dev">join the OpenAustralia community mailing list</a>
+            href="https://groups.google.com/group/openaustralia-dev">join the OpenAustralia community mailing list</a>
         to discuss things.</p>
 
     <h3>Examples</h3>


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://groups.google.com not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
