### PR TITLE
Use https://data.openaustralia.org not http

### DIFF
--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1254,7 +1254,7 @@ class PAGE {
                 $links[] = '<a href="' . $URL->generate() . '">' . $title . '</a>';
             }
         }
-        $links[] = '<a href="' . WEBPATH . 'api/">API</a> / <a href="http://data.openaustralia.org">XML</a>';
+        $links[] = '<a href="' . WEBPATH . 'api/">API</a> / <a href="https://data.openaustralia.org">XML</a>';
         $links[] = '<a href="https://software.openaustralia.org">Source code</a>';
 
         $qs = $_SERVER['QUERY_STRING'];

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1254,7 +1254,7 @@ class PAGE {
                 $links[] = '<a href="' . $URL->generate() . '">' . $title . '</a>';
             }
         }
-        $links[] = '<a href="' . WEBPATH . 'api/">API</a> / <a href="https://data.openaustralia.org">XML</a>';
+        $links[] = '<a href="' . WEBPATH . 'api/">API</a> / <a href="https://data.openaustralia.org.au">XML</a>';
         $links[] = '<a href="https://software.openaustralia.org">Source code</a>';
 
         $qs = $_SERVER['QUERY_STRING'];

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -151,7 +151,7 @@
         <p>Yes. If you just need a spreadsheet of
             representatives, you'll find one on the right hand side of <a href="/mps">this page</a>. If you need a
             full-blown API (Application Programming Interface), which gives you the power to do almost anything with our
-            data, <a href="/api">we have that too</a>. We also give you <a href="http://data.openaustralia.org">direct
+            data, <a href="/api">we have that too</a>. We also give you <a href="https://data.openaustralia.org">direct
                 access to the XML data</a> which gets loaded into our database.</p>
 
         <p>Please <a href="mailto:contact&#64;openaustralia.org">mail us</a> if you want help

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -151,7 +151,7 @@
         <p>Yes. If you just need a spreadsheet of
             representatives, you'll find one on the right hand side of <a href="/mps">this page</a>. If you need a
             full-blown API (Application Programming Interface), which gives you the power to do almost anything with our
-            data, <a href="/api">we have that too</a>. We also give you <a href="https://data.openaustralia.org">direct
+            data, <a href="/api">we have that too</a>. We also give you <a href="https://data.openaustralia.org.au">direct
                 access to the XML data</a> which gets loaded into our database.</p>
 
         <p>Please <a href="mailto:contact&#64;openaustralia.org">mail us</a> if you want help


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://data.openaustralia.org not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
