### PR TITLE
Use https://au.php.net not http

### DIFF
--- a/www/includes/strptime.php
+++ b/www/includes/strptime.php
@@ -8,7 +8,7 @@ if (!function_exists('strptime')) {
 
     /**
      * Implementation of strptime() for PHP on Windows.
-     * Modified from http://au.php.net/manual/en/function.strptime.php#82004
+     * Modified from https://au.php.net/manual/en/function.strptime.php#82004
      *
      * @param string $date
      *   Date string to parse.
@@ -87,7 +87,7 @@ if (!function_exists('strptime')) {
 
     /**
      * Called by strptime().
-     * Modified from http://au.php.net/manual/en/function.strptime.php#81611
+     * Modified from https://au.php.net/manual/en/function.strptime.php#81611
      *
      * @param string $date
      *   Date string to parse.


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://au.php.net not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
