### PR TITLE
Use https://aph.gov.au not http

### DIFF
--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -212,7 +212,7 @@ function api_front_page($error = '') {
     <p>
         Parliamentary material (that's data returned from getDebates and
         getHansard), is Copyright Commonwealth of Australia and is
-        <a href="https://aph.gov.au/legal/copyright.htm">provided by them</a>
+        <a href="https://www.aph.gov.au/Help/Disclaimer_Privacy_Copyright#c">provided by them</a>
         under a <a href="http://creativecommons.org/licenses/by-nc-nd/3.0/au/">
             Creative Commons 3.0 Attribution-NonCommercial-NoDerivs</a> licence.
     </p>

--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -212,7 +212,7 @@ function api_front_page($error = '') {
     <p>
         Parliamentary material (that's data returned from getDebates and
         getHansard), is Copyright Commonwealth of Australia and is
-        <a href="http://aph.gov.au/legal/copyright.htm">provided by them</a>
+        <a href="https://aph.gov.au/legal/copyright.htm">provided by them</a>
         under a <a href="http://creativecommons.org/licenses/by-nc-nd/3.0/au/">
             Creative Commons 3.0 Attribution-NonCommercial-NoDerivs</a> licence.
     </p>


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https://aph.gov.au not http

## Why was this needed?

Consistency with the fixing of internal links and to see the wood for the trees in the site report

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
