### PR TITLE
Use https not http for links and redirections

### DIFF
--- a/scripts/mprss.php
+++ b/scripts/mprss.php
@@ -54,7 +54,7 @@ for ($personrow = 0; $personrow < $q->rows(); $personrow++) {
             $title = htmlentities(str_replace('&#8212;', '-', $row['parent']['body']));
 
             $link = $row['listurl'] ?? '';
-            $link = 'http://' . DOMAIN . $link;
+            $link = 'https://' . DOMAIN . $link;
 
             $description = htmlentities(trim_characters($row['body'], 0, 200));
             $contentencoded = $row['body'];
@@ -89,9 +89,9 @@ for ($personrow = 0; $personrow < $q->rows(); $personrow++) {
   xmlns="http://purl.org/rss/1.0/"
   xmlns:content="http://purl.org/rss/1.0/modules/content/">
 		
-<channel rdf:about="http://' . DOMAIN . $mpurl . '">
+<channel rdf:about="https://' . DOMAIN . $mpurl . '">
 <title>' . entities_to_numbers($MEMBER->full_name()) . '\'s recent appearances (OpenAustralia.org)</title>
-<link>http://' . DOMAIN . $mpurl . '</link>
+<link>https://' . DOMAIN . $mpurl . '</link>
 <description></description>
 <dc:language>en-gb</dc:language>
 <dc:creator>OpenAustralia.org, mprss.php script</dc:creator>

--- a/www/docs/admin/report.php
+++ b/www/docs/admin/report.php
@@ -295,7 +295,7 @@ function resolve($REPORT, $COMMENT) {
 
             } else {
                 $data['template'] = 'report_declined';
-                $merge['COMMENTURL'] = 'http://' . DOMAIN . $COMMENT->url();
+                $merge['COMMENTURL'] = 'https://' . DOMAIN . $COMMENT->url();
                 $merge['REASON'] = get_http_var('declinedreason');
             }
 
@@ -316,7 +316,7 @@ function resolve($REPORT, $COMMENT) {
 
             // Create the URL for if a user wants to return and post another comment.
             // Remove the anchor for their now deleted comment.
-            $addcommentsurl = 'http://' . DOMAIN . preg_replace("/#.*$/", '#addcomment', $COMMENT->url());
+            $addcommentsurl = 'https://' . DOMAIN . preg_replace("/#.*$/", '#addcomment', $COMMENT->url());
 
             $data = [
             'to' => $USER->email(),

--- a/www/docs/api/api_getDebates.php
+++ b/www/docs/api/api_getDebates.php
@@ -105,7 +105,7 @@ function api_getDebates_type($t) {
         if (is_string($redirect)) {
             $URL = $_SERVER['REQUEST_URI'];
             $URL = str_replace($gid, $redirect, $URL);
-            // header('Location: http://' . DOMAIN . $URL);
+            // header('Location: https://' . DOMAIN . $URL);
             // exit;.
         }
     } elseif ($y = get_http_var('year')) {

--- a/www/docs/debate/index.php
+++ b/www/docs/debate/index.php
@@ -30,7 +30,7 @@ if (get_http_var('id') != '') {
     if (is_string($result)) {
         $URL = new URL('debate');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 

--- a/www/docs/debates/index.php
+++ b/www/docs/debates/index.php
@@ -72,7 +72,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('debates');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 

--- a/www/docs/debates/mobile.php
+++ b/www/docs/debates/mobile.php
@@ -77,7 +77,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('debates');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -101,7 +101,7 @@ if (get_http_var('recent')) {
     if ($pid) {
         $URL = new URL('search');
         $URL->insert(['pid' => $pid, 'pop' => 1]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'));
+        header('Location: https://' . DOMAIN . $URL->generate('none'));
         exit;
     }
 }

--- a/www/docs/mp/mobile.php
+++ b/www/docs/mp/mobile.php
@@ -106,7 +106,7 @@ if (get_http_var('recent')) {
     if ($pid) {
         $URL = new URL('search');
         $URL->insert(['pid' => $pid, 'pop' => 1]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'));
+        header('Location: https://' . DOMAIN . $URL->generate('none'));
         exit;
     }
 }

--- a/www/docs/news/rdf.php
+++ b/www/docs/news/rdf.php
@@ -13,9 +13,9 @@ print '<?xml version="1.0" encoding="iso-8859-1"?>' ?>
     xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:admin="http://webns.net/mvcb/"
     xmlns:cc="http://web.resource.org/cc/" xmlns="http://purl.org/rss/1.0/">
 
-    <channel rdf:about="http://<?php DOMAIN . WEBPATH . "news/" ?>">
+    <channel rdf:about="https://<?php DOMAIN . WEBPATH . "news/" ?>">
         <title>OpenAustralia News</title>
-        <link>http://<?php echo DOMAIN . WEBPATH . "news/" ?></link>
+        <link>https://<?php echo DOMAIN . WEBPATH . "news/" ?></link>
         <description>The weblog for news about site updates, etc.</description>
         <dc:language>en-us</dc:language>
         <dc:creator></dc:creator>
@@ -31,7 +31,7 @@ print '<?xml version="1.0" encoding="iso-8859-1"?>' ?>
                         break;
                     }
                     [$title, $content, $date] = $news_row;
-                    $url = "http://" . DOMAIN . news_individual_link($date, $title);
+                    $url = "https://" . DOMAIN . news_individual_link($date, $title);
                     print "<rdf:li rdf:resource=\"$url\" />\n";
                 }
                 ?>
@@ -47,7 +47,7 @@ print '<?xml version="1.0" encoding="iso-8859-1"?>' ?>
             break;
         }
         [$title, $content, $date] = $news_row;
-        $url = "http://" . DOMAIN . news_individual_link($date, $title);
+        $url = "https://" . DOMAIN . news_individual_link($date, $title);
         $excerpt = trim_characters(news_format_body($content), 0, 250);
         $date = str_replace(" ", "T", $date) . "+00:00";
         ?>

--- a/www/docs/ni/index.php
+++ b/www/docs/ni/index.php
@@ -48,7 +48,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('nidebates');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 
@@ -92,7 +92,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('nidebate');
         $URL->insert(['gid' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'));
+        header('Location: https://' . DOMAIN . $URL->generate('none'));
         exit;
     }
     if ($NILIST->htype() == '12' || $NILIST->htype() == '13') {

--- a/www/docs/rss/index.php
+++ b/www/docs/rss/index.php
@@ -30,7 +30,7 @@ if (validate_postcode($pc)) {
         }
 
         if ($MEMBER->person_id()) {
-            header('Location: http://' . DOMAIN . '/rss/mp/' . $MEMBER->person_id() . '.rdf');
+            header('Location: https://' . DOMAIN . '/rss/mp/' . $MEMBER->person_id() . '.rdf');
         }
     }
 } else {

--- a/www/docs/senate/index.php
+++ b/www/docs/senate/index.php
@@ -69,7 +69,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('lordsdebates');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 
@@ -123,7 +123,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('lordsdebate');
         $URL->insert(['gid' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
     if ($LORDSDEBATELIST->htype() == '12' || $LORDSDEBATELIST->htype() == '13') {

--- a/www/docs/senate/mobile.php
+++ b/www/docs/senate/mobile.php
@@ -74,7 +74,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('lordsdebates');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 
@@ -131,7 +131,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('lordsdebate');
         $URL->insert(['gid' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
     if ($LORDSDEBATELIST->htype() == '12' || $LORDSDEBATELIST->htype() == '13') {

--- a/www/docs/sp/index.php
+++ b/www/docs/sp/index.php
@@ -48,7 +48,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('spdebates');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 
@@ -92,7 +92,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('spdebate');
         $URL->insert(['gid' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'));
+        header('Location: https://' . DOMAIN . $URL->generate('none'));
         exit;
     }
     if ($LIST->htype() == '12' || $LIST->htype() == '13') {

--- a/www/docs/spwrans/index.php
+++ b/www/docs/spwrans/index.php
@@ -27,7 +27,7 @@ if (get_http_var('d')) {
     if ($gid) {
         $URL = new URL('spwrans');
         $URL->insert(['id' => $gid]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
     $PAGE->error_message("Couldn't match that Scottish Parliament ID to a GID.");
@@ -67,7 +67,7 @@ if (get_http_var('d')) {
     if (is_string($result)) {
         $URL = new URL('spwrans');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 

--- a/www/docs/user/changepc/index.php
+++ b/www/docs/user/changepc/index.php
@@ -15,7 +15,7 @@ if (get_http_var('forget') == 't') {
 
     // The cookie will have already been read for this page, so we need to reload.
     $URL = new URL($this_page);
-    header("Location: http://" . DOMAIN . $URL->generate());
+    header("Location: https://" . DOMAIN . $URL->generate());
 }
 
 if (!$THEUSER->constituency_is_set()) {

--- a/www/docs/whall/index.php
+++ b/www/docs/whall/index.php
@@ -63,7 +63,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('whall');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 
@@ -121,7 +121,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('whall');
         $URL->insert(['gid' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
     if ($WHALLLIST->htype() == '12' || $WHALLLIST->htype() == '13') {

--- a/www/docs/wms/index.php
+++ b/www/docs/wms/index.php
@@ -83,7 +83,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('wms');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 

--- a/www/docs/wrans/index.php
+++ b/www/docs/wrans/index.php
@@ -59,7 +59,7 @@ if (get_http_var("d") != "") {
     if (is_string($result)) {
         $URL = new URL('wrans');
         $URL->insert(['id' => $result]);
-        header('Location: http://' . DOMAIN . $URL->generate('none'), TRUE, 301);
+        header('Location: https://' . DOMAIN . $URL->generate('none'), TRUE, 301);
         exit;
     }
 

--- a/www/includes/easyparliament/alert.php
+++ b/www/includes/easyparliament/alert.php
@@ -334,7 +334,7 @@ class ALERT {
 
         $urltoken = $this->alert_id . '-' . $this->registrationtoken;
 
-        $confirmurl = 'http://' . DOMAIN . WEBPATH . 'A/' . $urltoken;
+        $confirmurl = 'https://' . DOMAIN . WEBPATH . 'A/' . $urltoken;
 
         // Arrays we need to send a templated email.
         $data = [

--- a/www/includes/easyparliament/commentreport.php
+++ b/www/includes/easyparliament/commentreport.php
@@ -351,7 +351,7 @@ class COMMENTREPORT {
             $emailbody = "A new comment report has been filed by " . $this->user_name() . ".\n\n";
             $emailbody .= "COMMENT:\n" . $COMMENT->body() . "\n\n";
             $emailbody .= "REPORT:\n" . $this->body . "\n\n";
-            $emailbody .= "To manage this report follow this link: http://" . DOMAIN . $URL->generate('none') . "\n";
+            $emailbody .= "To manage this report follow this link: https://" . DOMAIN . $URL->generate('none') . "\n";
 
             send_email(REPORTLIST, 'New comment report', $emailbody);
 
@@ -370,7 +370,7 @@ class COMMENTREPORT {
             $merge = [
                 'FIRSTNAME' => $this->firstname(),
                 'LASTNAME' => $this->lastname(),
-                'COMMENTURL' => "http://" . DOMAIN . $COMMENT->url(),
+                'COMMENTURL' => "https://" . DOMAIN . $COMMENT->url(),
                 'REPORTBODY' => strip_tags($this->body())
             ];
 

--- a/www/includes/easyparliament/hansardlist.php
+++ b/www/includes/easyparliament/hansardlist.php
@@ -2261,13 +2261,13 @@ class HANSARDLIST {
      * } else {
      * $url = $itemdata['commentsurl'];
      * }
-     * $trackback['itemurl'] = 'http://' . DOMAIN . $url;
+     * $trackback['itemurl'] = 'https://' . DOMAIN . $url;
      *
      * Getting the URL the user needs to ping for this item.
      * $URL = new URL('trackback');
      * $URL->insert(array('e'=>$itemdata['epobject_id']));
      *
-     * $trackback['pingurl'] = 'http://' . DOMAIN . $URL->generate('html');
+     * $trackback['pingurl'] = 'https://' . DOMAIN . $URL->generate('html');
      *
      *
      * return $trackback;

--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -741,7 +741,7 @@ class MEMBER {
         }
         $member_url = make_member_url($this->full_name(TRUE), $this->constituency(), $house);
         if ($absolute) {
-            return 'http://' . DOMAIN . $URL->generate('none') . $member_url;
+            return 'https://' . DOMAIN . $URL->generate('none') . $member_url;
         } else {
             return $URL->generate('none') . $member_url;
         }

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -311,7 +311,7 @@ class PAGE {
                 content="Parliament, government, House of Representatives, Senate, Senator, MP, Member of Parliament, MPs, Australia, Australian, <?php echo htmlentities($keywords_title) . htmlentities($keywords); ?>">
             <meta name="verify-v1" content="5FBaCDi8kCKdo4s64NEdB5EOJDNc310SwcLLYHmEbgg=">
             <link rel="author" title="Send feedback" href="mailto:<?php echo str_replace('@', '&#64;', CONTACTEMAIL); ?>">
-            <link rel="home" title="Home" href="http://<?php echo DOMAIN; ?>/">
+            <link rel="home" title="Home" href="https://<?php echo DOMAIN; ?>/">
             <?php
             echo $linkshtml;
 
@@ -321,7 +321,7 @@ class PAGE {
                 // If this page has an RSS feed set.
                 ?>
                 <link rel="alternate" type="application/rss+xml" title="OpenAustralia RSS"
-                    href="http://<?php echo DOMAIN . WEBPATH . $rssurl; ?>">
+                    href="https://<?php echo DOMAIN . WEBPATH . $rssurl; ?>">
                 <?php
             }
 
@@ -448,7 +448,7 @@ class PAGE {
             <meta name="verify-v1" content="5FBaCDi8kCKdo4s64NEdB5EOJDNc310SwcLLYHmEbgg=">
             <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0" />
             <link rel="author" title="Send feedback" href="mailto:<?php echo str_replace('@', '&#64;', CONTACTEMAIL); ?>">
-            <link rel="home" title="Home" href="http://<?php echo DOMAIN; ?>/">
+            <link rel="home" title="Home" href="https://<?php echo DOMAIN; ?>/">
             <?php
             echo $linkshtml;
 
@@ -458,7 +458,7 @@ class PAGE {
                 // If this page has an RSS feed set.
                 ?>
                 <link rel="alternate" type="application/rss+xml" title="OpenAustralia RSS"
-                    href="http://<?php echo DOMAIN . WEBPATH . $rssurl; ?>">
+                    href="https://<?php echo DOMAIN . WEBPATH . $rssurl; ?>">
                 <?php
             }
 

--- a/www/includes/easyparliament/staticpages/linktous.php
+++ b/www/includes/easyparliament/staticpages/linktous.php
@@ -10,7 +10,7 @@
 <p>Alternatively, if you would like to place an OpenAustralia search box on your site, like this one&hellip;</p>
 
 <?php
-$url = "http://" . DOMAIN . WEBPATH;
+$url = "https://" . DOMAIN . WEBPATH;
 $link_to_us_form = <<<END
 <!-- OpenAustralia box, begin -->
 <div style='position: relative; width: 17em; color: #000000; background-color: #EBECCF; font-family: Arial, Geneva, Sans-serif; margin-bottom: 1em; border: 1px solid #AE967F; padding: 0 10px 2em 10px;'>

--- a/www/includes/easyparliament/templates/csv/people_mps.php
+++ b/www/includes/easyparliament/templates/csv/people_mps.php
@@ -56,7 +56,7 @@ function render_mps_row($mp, $order) {
     } else {
         print $mp['party'];
     }
-    print ',' . $con . ',http://' . DOMAIN . WEBPATH . 'mp/' .
+    print ',' . $con . ',https://' . DOMAIN . WEBPATH . 'mp/' .
         make_member_url($mp['first_name'] . ' ' . $mp['last_name'], $mp['constituency']);
     if ($order == 'expenses') {
         print ', �' . $mp['data_value'];

--- a/www/includes/easyparliament/templates/csv/people_peers.php
+++ b/www/includes/easyparliament/templates/csv/people_peers.php
@@ -35,6 +35,6 @@ function render_peers_row($peer, $order) {
     } else {
         print $peer['party'];
     }
-    print ',http://' . DOMAIN . WEBPATH . 'senator/' . make_member_url($name, $peer['constituency']);
+    print ',https://' . DOMAIN . WEBPATH . 'senator/' . make_member_url($name, $peer['constituency']);
     print "\n";
 }

--- a/www/includes/easyparliament/user.php
+++ b/www/includes/easyparliament/user.php
@@ -346,7 +346,7 @@ class USER {
 
         $urltoken = $this->user_id . '-' . $this->registrationtoken;
 
-        $confirmurl = 'http://' . DOMAIN . WEBPATH . 'U/' . $urltoken;
+        $confirmurl = 'https://' . DOMAIN . WEBPATH . 'U/' . $urltoken;
 
         // Arrays we need to send a templated email.
         $data = [
@@ -469,7 +469,7 @@ class USER {
 
         $merge = [
             'EMAIL' => $this->email(),
-            'LOGINURL' => "http://" . DOMAIN . $URL->generate(),
+            'LOGINURL' => "https://" . DOMAIN . $URL->generate(),
             'PASSWORD' => $this->password()
         ];
 

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -90,7 +90,7 @@ function error_handler(string $errno, string $errmsg, string $filename, int $lin
 
     $err = '';
     if (isset($_SERVER['REQUEST_URI'])) {
-        $err .= "URL:\t\thttp://" . DOMAIN . $_SERVER['REQUEST_URI'] . "\n";
+        $err .= "URL:\t\thttps://" . DOMAIN . $_SERVER['REQUEST_URI'] . "\n";
     } else {
         $err .= "URL:\t\tNone - running from command line?\n";
     }


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/830

## What does this do?

Use https not http for internal links and redirections

## Why was this needed?

* Reduce the large list of redirections from internal https page to http page then apache redirecting back to https, 
* able to see the wood for the trees in the site report
* should improve site speed, halving the number of requests

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
