### PR TITLE
Add simple check-links script that checks php files and suggests action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,7 @@ test-coverage-docker:
 
 scripts/run-with-lockfile: scripts/run-with-lockfile.c
 	gcc -o scripts/run-with-lockfile scripts/run-with-lockfile.c
+
+check-links:
+	ruby scripts/check-links.rb
+

--- a/README.md
+++ b/README.md
@@ -153,3 +153,36 @@ script/dbconsole -p < ../twfy/db/schema.sql
 bundle exec rake db:fixtures:load   # for a limited set of fixtures
 bundle exec rake db:stats # to show which tables have data
 ```
+
+### Checking Links
+
+To perform a simplistic static check of links in php files, run:
+
+```bash
+make check-links
+```
+
+This will output suggested sed commands to run to fix urls in php files.
+NOTE: It isn't smart enough to handle dynamically generated urls, so check before applying recommendations.
+
+It follows permanent redirections and suggests the url be updated accordingly, for example (note the http to https
+change and the slash added to the end of the url):
+
+```
+sed -i 's|http://theyworkforyou.com/api|https://www.theyworkforyou.com/api/|g' www/docs/api/index.php
+```
+
+It will report broken links (check it is not part of a dynamic link that does work when checked in full):
+
+```
+# BROKEN http://hurring.com/code/python/serialize/ (404) in files: www/docs/api/index.php
+# BROKEN https://www.aph.gov.au/Help/Disclaimer_Privacy_Copyright#c (403) in files: www/docs/api/index.php
+```
+
+It will list temporary redirections, which you probably should leave as is, aside from changing http to https where
+appropriate:
+
+```
+# Ignore 302 redirect http://creativecommons.org/licenses/by-nc-nd/3.0/au/ to https://creativecommons.org/licenses/by-nc-nd/3.0/au/ in files: www/docs/api/index.php
+# Ignore 302 redirect http://creativecommons.org/licenses/by-sa/2.5/ to https://creativecommons.org/licenses/by-sa/2.5/ in files: www/docs/api/index.php
+```

--- a/scripts/check-links.rb
+++ b/scripts/check-links.rb
@@ -60,7 +60,7 @@ Dir.glob('**/*.php').each do |file|
   next if file.start_with? "vendor/"
 
   puts "Parsing #{file}..."
-  File.read(file).scan(%r{https?://[^\s"'<>]+}).each do |url|
+  File.read(file).scan(%r{https?://[^\s"'<>\\\{\}\(\)]+}).each do |url|
     url_files[url] << file unless EXCLUDED.any? { |ex| url.include?(ex) }
   end
 end
@@ -93,11 +93,11 @@ end
 puts "Results...", ""
 
 puts
-fmt = "%-12s %6s" 
+fmt = "%-12s %6s"
 puts fmt % ["Status", "Count"]
 puts fmt % ["-" * 12, "-" * 6]
 total = 0
-counts.sort.each do |code, count|
+counts.sort_by { |code, _| code.to_s }.each do |code, count|
   puts fmt % [code, count]
   total += count
 end

--- a/scripts/check-links.rb
+++ b/scripts/check-links.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+require 'net/http'
+require 'uri'
+
+EXCLUDED = %w[example.com]
+MAX_REDIRECTS = 10
+
+def follow(url, limit = MAX_REDIRECTS)
+  STDOUT.flush
+  return [:error, "too many redirects"] if limit == 0
+
+  begin
+    uri = URI.parse(url)
+  rescue URI::InvalidURIError
+    return [:error, "bad URI: #{url}"]
+  end
+  return [:error, "not HTTP/HTTPS"] unless uri.is_a?(URI::HTTP)
+
+  begin
+    res = Net::HTTP.get_response(uri)
+  rescue => e
+    return [:error, e.message]
+  end
+
+  code = res.code.to_i
+  case code
+  when 200..299
+    [:ok, code]
+  when 301, 308
+    dest = res['location']
+    inner = follow(dest, limit - 1)
+    final = case inner[0]
+            when :ok        then dest
+            when :temp      then inner[1]
+            when :permanent then inner[1]
+            else return [inner[0], "redirect to broken link: #{dest}"]
+            end
+    [:permanent, final, code]
+  when 302, 303, 307
+    [:temp, res['location'], code]
+  when 400..599
+    [code, "HTTP #{code}"]
+  else
+    [code, "unexpected HTTP #{code}"]
+  end
+end
+
+def format_files(files)
+  uniq = files.uniq
+  if uniq.size > 5
+    "#{uniq.first(5).join(', ')}, and #{uniq.size - 5} more"
+  else
+    uniq.join(', ')
+  end
+end
+
+url_files = Hash.new { |h, k| h[k] = [] }
+
+Dir.glob('**/*.php').each do |file|
+  next if file.start_with? "vendor/"
+
+  puts "Parsing #{file}..."
+  File.read(file).scan(%r{https?://[^\s"'<>]+}).each do |url|
+    url_files[url] << file unless EXCLUDED.any? { |ex| url.include?(ex) }
+  end
+end
+
+puts "Checking urls ..."
+
+counts              = Hash.new(0)
+permanent_redirects = []
+temp_redirects      = []
+broken              = []
+
+url_files.each do |url, files|
+  result = follow(url)
+  source = format_files(files)
+
+  status = result[0]
+  counts[status] += 1
+  case status
+  when :ok
+    # ignore
+  when :permanent
+    puts "sed -i 's|#{url}|#{result[1]}|g' #{files.join(' ')}"
+  when :temp
+    puts "# Ignore #{result[2]} redirect #{url} to #{result[1]} in files: #{source}"
+  else
+    puts "# BROKEN #{url} (#{status}) in files: #{source}"
+  end
+end
+
+puts "Results...", ""
+
+puts
+fmt = "%-12s %6s" 
+puts fmt % ["Status", "Count"]
+puts fmt % ["-" * 12, "-" * 6]
+total = 0
+counts.sort.each do |code, count|
+  puts fmt % [code, count]
+  total += count
+end
+puts fmt % ["", "=" * 6]
+puts fmt % ["Total", total]


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/878

## What does this do?

Checks links found in php files

Outputs a sed command to rectify permanent redirections

Outputs comments on 
* ignoring temp redirections
* broken links to follow up on

Note - this doesn't understand php expressions, and is simplistic in its approach - the goal is catching 95% not 100%

## Why was this needed?

The links haven’t been checked for ages and it would be laborious to check manually

## Implementation/Deploy Steps (Optional)

```
ruby script/check-links.rb
```

## Notes to reviewer (Optional)

This is an independent script which does nothing to code itself.
The reviewer needs to choose if the sed commands that are output should be run
and the results committed.

It is suggested that the changes made by each sed command should be a separate branch and PR

Example output from run (5 minutes):
```
$ ruby scripts/check-links.rb

Parsing _ide_helper.php...
Parsing scripts/alertgonemps.php...
Parsing scripts/alertmailer.php...
...
Parsing www/includes/utility.php...
Parsing www/includes/wikipedia.php...
Checking urls ...
Parsing www/includes/utility.php...
Parsing www/includes/wikipedia.php...
Checking urls ...
sed -i 's|http://www.openaustralia.org/user/|/user/login/?ret=%2Fuser%2F|g' scripts/alertgonemps.php scripts/alertmailer.php
sed -i 's|http://www.openaustralia.org|https://www.openaustralia.org.au/|g' scripts/alertmailer.php www/docs/gadget/debateday.php www/includes/easyparliament/templates/rss/hansard_search.php www/includes/easyparliament/templates/rss/hansard_search.php www/includes/easyparliament/templates/rss/hansard_search.php
sed -i 's|http://www.openaustralia.org/search/?s=|https://www.openaustralia.org.au/search/?s=|g' scripts/alertmailer.php
sed -i 's|http://www.openaustralia.org/D/|https://www.openaustralia.org.au/D/|g' scripts/alertmailer.php
# Ignore 302 redirect http://purl.org/dc/elements/1.1/ to https://purl.org/dc/elements/1.1/ in files: scripts/mprss.php, www/docs/news/rdf.php, www/includes/easyparliament/page.php
sed -i 's|http://www.w3.org/1999/02/22-rdf-syntax-ns#|https://www.w3.org/1999/02/22-rdf-syntax-ns|g' scripts/mprss.php www/docs/news/rdf.php www/includes/easyparliament/page.php
# Ignore 302 redirect http://purl.org/rss/1.0/ to https://purl.org/rss/1.0/ in files: scripts/mprss.php, www/docs/news/rdf.php
# Ignore 302 redirect http://purl.org/rss/1.0/modules/content/ to https://purl.org/rss/1.0/modules/content/ in files: scripts/mprss.php
sed -i 's|http://en.wikipedia.org/wiki/|https://en.wikipedia.org/wiki/Main_Page|g' www/docs/admin/glossary_pending.php
sed -i 's|http://en.wikipedia.org/wiki/Earth_radius|https://en.wikipedia.org/wiki/Earth_radius|g' www/docs/api/api_getConstituencies.php
sed -i 's|http://www.openaustralia.org/api/key|https://www.openaustralia.org.au/api/key|g' www/docs/api/index.php
sed -i 's|http://www.openaustralia.org/api/|https://www.openaustralia.org.au/api/|g' www/docs/api/index.php www/docs/api/index.php www/docs/api/index.php
# BROKEN http://hurring.com/code/python/serialize/ (404) in files: www/docs/api/index.php
...
# BROKEN http://www.whitelabel.org/archives/002248.html (410) in files: www/includes/wikipedia.php
# BROKEN http://en.wikipedia.org/wiki/{$wikistring (error) in files: www/includes/wikipedia.php
# BROKEN http://uk2.php.net/strip-tags) (error) in files: www/includes/wikipedia.php
Results...


Status        Count
------------ ------
403              19
404              13
410               2
500               2
error            19
ok               42
permanent        42
temp             10
             ======
Total           149
```

At the end it will output a table of http status's and counts of urls checked