### PR TITLE
fix access to stopwords and alphabet

### DIFF
--- a/tests/GlossaryTest.php
+++ b/tests/GlossaryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../www/includes/easyparliament/glossary.php';
+
+/**
+ *
+ */
+class GlossaryTest extends TestCase {
+
+    /**
+     *
+     */
+    public function test_get_stopwords_returns_internal_stopwords_array() {
+        $glossary = $this->newGlossaryWithoutConstructor();
+
+        $expectedStopwords = ['the', 'of', 'to'];
+        $this->setPrivateProperty($glossary, 'stopwords', $expectedStopwords);
+
+        $this->assertSame($expectedStopwords, $glossary->get_stopwords());
+    }
+
+    /**
+     *
+     */
+    public function test_get_alphabet_returns_internal_alphabet_array() {
+        $glossary = $this->newGlossaryWithoutConstructor();
+
+        $expectedAlphabet = [
+            'A' => [1, 2],
+            'B' => [3],
+            'C' => [],
+        ];
+        $this->setPrivateProperty($glossary, 'alphabet', $expectedAlphabet);
+
+        $this->assertSame($expectedAlphabet, $glossary->get_alphabet());
+    }
+
+    /**
+     *
+     */
+    private function newGlossaryWithoutConstructor(): GLOSSARY {
+        $reflection = new ReflectionClass(GLOSSARY::class);
+        return $reflection->newInstanceWithoutConstructor();
+    }
+
+    /**
+     *
+     */
+    private function setPrivateProperty(object $object, string $property, mixed $value): void {
+        $reflection = new ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+    }
+
+}

--- a/www/docs/addterm/index.php
+++ b/www/docs/addterm/index.php
@@ -28,7 +28,7 @@ if ((get_http_var('g') != '') && (get_http_var('previewterm') == '')) {
 
 // Check that people aren't trying to define silly words.
 if (
-    in_array(strtolower($GLOSSARY->query), $GLOSSARY->stopwords)
+    in_array(strtolower($GLOSSARY->query), $GLOSSARY->get_stopwords())
 ) {
     $GLOSSARY->query = "";
     $args['blankform'] = 1;

--- a/www/docs/glossary/index.php
+++ b/www/docs/glossary/index.php
@@ -42,7 +42,8 @@ if ((get_http_var('az') != '') && is_string(get_http_var('az'))) {
 }
 
 // Now check it's in the populated glossary alphabet.
-if (isset($az) && array_key_exists($az, $GLOSSARY->alphabet)) {
+$alphabet = $GLOSSARY->get_alphabet();
+if (isset($az) && array_key_exists($az, $alphabet)) {
     $GLOSSARY->current_letter = $az;
     // Otherwise make it the first letter of the current term.
 } elseif (isset($term)) {
@@ -114,7 +115,7 @@ if ($GLOSSARY->glossary_id != '') {
         <ul class="glossary">
             <?php
             $URL = new URL('glossary');
-            foreach ($GLOSSARY->alphabet[$GLOSSARY->current_letter] as $glossary_id) {
+            foreach ($alphabet[$GLOSSARY->current_letter] as $glossary_id) {
                 $URL->insert(['gl' => $glossary_id]);
                 $term_link = $URL->generate('url');
                 ?>

--- a/www/includes/easyparliament/glossary.php
+++ b/www/includes/easyparliament/glossary.php
@@ -100,6 +100,20 @@ class GLOSSARY {
     }
 
     /**
+     * Backward-compatible read access for callers outside this class.
+     */
+    public function get_stopwords() {
+        return $this->stopwords;
+    }
+
+    /**
+     * Backward-compatible read access for callers outside this class.
+     */
+    public function get_alphabet() {
+        return $this->alphabet;
+    }
+
+    /**
      *
      */
     private function get_glossary_item($args = []):int {

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -2723,8 +2723,9 @@ class PAGE {
         // Print out a nice list of lettered links to glossary pages.
 
         $letters = [];
+        $alphabet = $GLOSSARY->get_alphabet();
 
-        foreach ($GLOSSARY->alphabet as $letter => $eps) {
+        foreach ($alphabet as $letter => $eps) {
             // If we're writing out the current letter (list or item)
             if ($letter == $GLOSSARY->current_letter) {
                 // If we're in item view - show the letter as "on" but make it a link.
@@ -2738,7 +2739,7 @@ class PAGE {
                     // Otherwise in list view show no link.
                     $letters[] = "<li class=\"on\">" . $letter . "</li>";
                 }
-            } elseif (!empty($GLOSSARY->alphabet[$letter])) {
+            } elseif (!empty($alphabet[$letter])) {
                 $URL = new URL('glossary');
                 $URL->insert(['az' => $letter]);
                 $letter_link = $URL->generate('url');


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?
## Why was this needed?

adds getter methods for alphabet and stop words

## Implementation/Deploy Steps (Optional)

errors on production:
`PHP Fatal error:  Uncaught Error: Cannot access private property GLOSSARY::$stopwords in /srv/www/production/releases/20260517060354/twfy/www/docs/addterm/index.php:31\nStack trace:\n#0 {main}\n  thrown in /srv/www/production/releases/20260517060354/twfy/www/docs/addterm/index.php on line 31, referer: http://www.baidu.org.au/
`

## Notes to reviewer (Optional)
