### PR TITLE
morning update needs xapian

### DIFF
--- a/scripts/morningupdate
+++ b/scripts/morningupdate
@@ -54,7 +54,7 @@ $VERBOSE && echo "Parsing from APH to XML and loading into the database"
 # ./xml2db.pl $CRONQUIET --recent --lordsdebates
 #./xml2db.pl $CRONQUIET --recent --ni --quiet
 
-if [ -v "$XAPIANDB" ]; then
+if [ -n "$XAPIANDB" ]; then
     # Update Xapan index
     $VERBOSE && echo "Xapian indexing"
     ../search/index.pl "$XAPIANDB" sincefile "$XAPIANDB/../searchdb-lastupdated" "$CRONQUIET_NODASH"


### PR DESCRIPTION
i think this was needed because of a bash upgrade

## Relevant issue(s)

the morning update doesn't index new speeches into xapian

## What does this do?

changes the bash script to detect that we have XAPIAN configured

## Why was this needed?

one part of fixing https://github.com/openaustralia/openaustralia/issues/793
