### PR TITLE
remove unneeded import

### DIFF
--- a/www/docs/alert/confirm/index.php
+++ b/www/docs/alert/confirm/index.php
@@ -34,7 +34,6 @@
 
 include_once __DIR__ . '/../../../includes/easyparliament/init.php';
 include_once __DIR__ . '/../../../includes/easyparliament/member.php';
-include_once __DIR__ . '/../../../../../phplib/crosssell.php';
 
 // Instantiate an instance of ALERT.
 

--- a/www/docs/alert/index.php
+++ b/www/docs/alert/index.php
@@ -19,7 +19,6 @@ include_once __DIR__ . '/../../includes/easyparliament/init.php';
 include_once __DIR__ . '/../../includes/easyparliament/people.php';
 include_once __DIR__ . '/../../includes/easyparliament/member.php';
 include_once __DIR__ . '/../../../../phplib/auth.php';
-include_once __DIR__ . '/../../../../phplib/crosssell.php';
 
 $this_page = "alert";
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -8,7 +8,6 @@ if (defined('OPTION_TRACKING') && OPTION_TRACKING) {
     require_once __DIR__ . '/../../../../phplib/tracking.php';
 }
 
-include_once __DIR__ . '/../../../../phplib/gaze.php';
 include_once __DIR__ . '/member.php';
 include_once __DIR__ . '/../request.php';
 


### PR DESCRIPTION
## Relevant issue(s)
https://github.com/openaustralia/openaustralia/issues/834
## What does this do?
removes imports of php lib files that aren't needed.

## Why was this needed?

twfy was including files in `phplib` but not actually using any functions within those. That makes the import unnecessary.
