### PR TITLE
fix deprecation - lensort function using spaceship operator

### DIFF
--- a/www/includes/wikipedia.php
+++ b/www/includes/wikipedia.php
@@ -26,13 +26,6 @@
 /**
  *
  */
-function lensort($a, $b) {
-    return strlen($b) <=> strlen($a);
-}
-
-/**
- *
- */
 function wikipedize($source) {
     $was_array = false;
     if (is_array($source)) {
@@ -68,7 +61,7 @@ function wikipedize($source) {
     // We don't want no steenking duplicates.
     $phrases = array_unique(array_merge($propernounphrases1[0], $propernounphrases2[0], $propernounphrases3[1], $acronyms[0]));
     // Sort into order, largest first.
-    usort($phrases, "lensort");
+    usort($phrases, fn($a, $b) => strlen($b) <=> strlen($a));
 
     foreach ($phrases as $i => $phrase) {
         $phrases[$i] = str_replace(' ', '_', trim($phrase));

--- a/www/includes/wikipedia.php
+++ b/www/includes/wikipedia.php
@@ -27,7 +27,7 @@
  *
  */
 function lensort($a, $b) {
-    return strlen($a) < strlen($b);
+    return strlen($b) <=> strlen($a);
 }
 
 /**


### PR DESCRIPTION
## Relevant issue(s)
* https://github.com/openaustralia/openaustralia/issues/857

PHP 8 deprecation warning in lensort()

## What does this do?
use a spaceship

## Why was this needed?
A deprecation error appeared when i tested on staging
