### PR TITLE
Clarify archived register database link

### DIFF
--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -172,9 +172,10 @@
                 href="https://www.aph.gov.au/Parliamentary_Business/Committees/House_of_Representatives_Committees?url=pmi/index.htm">Standing
                 Committee of Privileges and Members' Interests</a>.</p>
 
-        <p>You might also be interested in <a href="https://www.smh.com.au/politics">a searchable database</a>
-            of the register, compiled by SMH. Note that this was created in 2012 and may not be up to
-            date.</p>
+        <p>The SMH published <a
+                href="https://web.archive.org/web/20130309030859/http://www.smh.com.au/national/political-interests">a
+                searchable database</a> of the register in 2012. The project is now defunct and the archived copy should
+            not be treated as current.</p>
     </dd>
 
     <dt><a name="regmem-links"></a>Why are there two Register of Interests links for some MPs?</dt>


### PR DESCRIPTION
## Summary

- replace the generic SMH politics link with a verified Internet Archive snapshot of the 2012 searchable register database
- describe the historical project as defunct and warn that the archived copy is not current
- keep the change limited to the existing Register of Interests help text

## Validation

- `php -l www/includes/easyparliament/staticpages/help.php` — passed with PHP 8.3.31
- `php vendor/bin/phpcs --standard=phpcs.xml --tab-width=4 www/includes/easyparliament/staticpages/help.php` — passed
- focused PHPUnit run covering 15 non-database test files — passed 126 tests with 165 assertions; 11 tests skipped
- `composer validate --no-check-publish` — passed
- `composer audit --no-interaction` — passed with no known security advisories
- archived URL check — returned HTTP 200 with the page title `Political Interests`
- targeted content assertions and `git diff --check` — passed
- full `php vendor/bin/phpunit tests/` — not clean locally: 115 tests passed, 58 skipped, and 77 database-dependent tests failed because MySQL was unavailable; Docker Desktop's Linux engine was not running

## Notes

- Fixes openaustralia/openaustralia#676.
- No application behavior, dependencies, or lockfiles are changed.
- GitHub Actions completed all 250 PHPUnit tests with 476 assertions, but the job is marked failed because fork pull requests do not receive the repository's `SONAR_TOKEN`. The schema job completed migrations and the schema dump, then failed when its sticky-comment action was denied permission to post to the pull request. PHP and Perl lint checks passed.
