### PR TITLE
convert admin pages to use models

### DIFF
--- a/www/docs/admin/alerts.php
+++ b/www/docs/admin/alerts.php
@@ -9,20 +9,20 @@ include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 include_once __DIR__ . "/../../includes/easyparliament/searchengine.php";
 include_once __DIR__ . "/../../includes/easyparliament/member.php";
 
+use Illuminate\Support\Collection;
+use OpenAustralia\TWFY\Models\Alert;
+use OpenAustralia\TWFY\Models\User as UserModel;
+
 $this_page = 'admin_alerts';
 
 $PAGE->page_start();
 $PAGE->stripe_start();
 
 print '<h4>Statistics</h4>';
-$q = parlDBQuery('SELECT COUNT(*) AS c FROM alerts');
-$total = $q->field(0, 'c');
-$q = parlDBQuery('SELECT COUNT(*) AS c FROM alerts WHERE confirmed=1 AND deleted=0');
-$active = $q->field(0, 'c');
-$q = parlDBQuery('SELECT COUNT(*) AS c FROM alerts WHERE deleted=1');
-$deleted = $q->field(0, 'c');
-$q = parlDBQuery('SELECT COUNT(*) AS c FROM alerts WHERE confirmed=0');
-$unconfirmed = $q->field(0, 'c');
+$total = Alert::query()->count();
+$active = Alert::query()->where('confirmed', 1)->where('deleted', 0)->count();
+$deleted = Alert::query()->where('deleted', 1)->count();
+$unconfirmed = Alert::query()->where('confirmed', 0)->count();
 $rows = [['Total', $total], ['Active', $active], ['Deleted', $deleted], ['Unconfirmed', $unconfirmed]];
 $tabledata = [
     'header' => ['Stat', 'Number'],
@@ -30,27 +30,46 @@ $tabledata = [
 ];
 $PAGE->display_table($tabledata);
 
-$order = 'email, alert_id';
-if (isset($_GET['o']) && $_GET['o'] == 'c') {
-    $order = 'created, alert_id';
-}
+$orderByCreated = isset($_GET['o']) && $_GET['o'] == 'c';
 
 print '<h4>Active alerts</h4>';
-$q = parlDBQuery('SELECT email,criteria,created FROM alerts WHERE confirmed=1 AND deleted=0 ORDER BY ' . $order);
+$q = Alert::query()
+  ->select(['email', 'criteria', 'created'])
+  ->where('confirmed', 1)
+  ->where('deleted', 0);
+if ($orderByCreated) {
+    $q->orderBy('created')->orderBy('alert_id');
+} else {
+    $q->orderBy('email')->orderBy('alert_id');
+}
 $tabledata = [
     'header' => ['<a href="alerts.php">Email</a>', 'Criteria', '<a href="alerts.php?o=c">Created</a>'],
-    'rows' => generate_rows($q)
+    'rows' => generate_rows($q->get())
 ];
 $PAGE->display_table($tabledata);
 
 print '<h4>Deleted alerts</h4>';
-$q = parlDBQuery('SELECT email,criteria,created FROM alerts WHERE deleted=1 ORDER BY ' . $order);
-$tabledata['rows'] = generate_rows($q);
+$q = Alert::query()
+  ->select(['email', 'criteria', 'created'])
+  ->where('deleted', 1);
+if ($orderByCreated) {
+    $q->orderBy('created')->orderBy('alert_id');
+} else {
+    $q->orderBy('email')->orderBy('alert_id');
+}
+$tabledata['rows'] = generate_rows($q->get());
 $PAGE->display_table($tabledata);
 
 print '<h4>Unconfirmed alerts</h4>';
-$q = parlDBQuery('SELECT email,criteria,created FROM alerts WHERE confirmed=0 ORDER BY ' . $order);
-$tabledata['rows'] = generate_rows($q);
+$q = Alert::query()
+  ->select(['email', 'criteria', 'created'])
+  ->where('confirmed', 0);
+if ($orderByCreated) {
+    $q->orderBy('created')->orderBy('alert_id');
+} else {
+    $q->orderBy('email')->orderBy('alert_id');
+}
+$tabledata['rows'] = generate_rows($q->get());
 $PAGE->display_table($tabledata);
 
 $menu = $PAGE->admin_menu();
@@ -66,23 +85,34 @@ $PAGE->page_end();
 /**
  *
  */
-function generate_rows($q) {
-    global $db;
+function generate_rows(Collection $alerts): array {
     $rows = [];
     $USERURL = new URL('userview');
-    for ($row = 0; $row < $q->rows(); $row++) {
-        $email = $q->field($row, 'email');
-        $criteria = $q->field($row, 'criteria');
+
+    if ($alerts->isEmpty()) {
+        return $rows;
+    }
+
+    $usersByEmail = UserModel::query()
+      ->whereIn('email', $alerts->pluck('email')->unique()->all())
+      ->get(['user_id', 'firstname', 'lastname', 'email'])
+      ->keyBy('email');
+
+    foreach ($alerts as $alert) {
+        $email = $alert->email;
+        $criteria = $alert->criteria;
         $SEARCHENGINE = new SEARCHENGINE($criteria);
-        $r = parlDBQuery("SELECT user_id,firstname,lastname FROM users WHERE email = ?", $email);
-        if ($r->rows() > 0) {
-            $user_id = $r->field(0, 'user_id');
+
+        $user = $usersByEmail->get($email);
+        if ($user) {
+            $user_id = $user->user_id;
             $USERURL->insert(['u' => $user_id]);
-            $name = '<a href="' . $USERURL->generate() . '">' . $r->field(0, 'firstname') . ' ' . $r->field(0, 'lastname') . '</a>';
+            $name = '<a href="' . $USERURL->generate() . '">' . $user->firstname . ' ' . $user->lastname . '</a>';
         } else {
             $name = $email;
         }
-        $created = $q->field($row, 'created');
+
+        $created = $alert->created;
         if ($created == '0000-00-00 00:00:00') {
             $created = '&nbsp;';
         }

--- a/www/docs/admin/badusers.php
+++ b/www/docs/admin/badusers.php
@@ -4,6 +4,9 @@
  * @file
  */
 
+use OpenAustralia\TWFY\Models\Commentreport;
+use OpenAustralia\TWFY\Models\Comments;
+
 include_once __DIR__ . "/../../includes//easyparliament/init.php";
 include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
@@ -37,24 +40,17 @@ for ($row = 0; $row < $q->rows(); $row++) {
     $user_id = $q->field($row, 'user_id');
 
     // Get the total comments posted for this user.
-    $r = parlDBQuery("SELECT COUNT(*) AS totalcount
-					FROM	comments
-					WHERE	user_id = '" . $user_id . "'");
-
-    $totalcomments = $r->field(0, 'totalcount');
+    $totalcomments = Comments::where('user_id', $user_id)->count();
 
     $percentagedeleted = ($q->field($row, 'deletedcount') / $totalcomments) * 100;
 
 
     // Get complaints made about this user's comments, but not upheld.
-    $r = parlDBQuery("SELECT COUNT(*) AS count
-					FROM commentreports, comments
-					WHERE	commentreports.comment_id = comments.comment_id
-					AND		comments.user_id = '$user_id'
-					AND		commentreports.resolved IS NOT NULL
-					AND		commentreports.upheld = '0'");
-
-    $notupheldcount = $r->field(0, 'count');
+    $notupheldcount = Comments::join('commentreports', 'commentreports.comment_id', '=', 'comments.comment_id')
+      ->where('comments.user_id', $user_id)
+      ->whereNotNull('commentreports.resolved')
+      ->where('commentreports.upheld', '0')
+      ->count();
 
 
     $USERURL->insert(['u' => $user_id]);
@@ -82,37 +78,34 @@ $PAGE->display_table($tabledata);
 ?>
 <h4>Users who've made most rejected reports</h4>
 <?php
-$q = parlDBQuery("SELECT COUNT(*) AS rejectedcount,
-						cr.user_id,
-						u.firstname,
-						u.lastname
-				FROM	commentreports cr, users u
-				WHERE	cr.resolved IS NOT NULL
-				AND		cr.upheld = '0'
-				AND		cr.user_id = u.user_id
-				AND		cr.user_id != 0
-				GROUP BY cr.user_id
-				ORDER BY rejectedcount DESC");
+$rejectedReports = Commentreport::join('users as u', 'commentreports.user_id', '=', 'u.user_id')
+  ->whereNotNull('commentreports.resolved')
+  ->where('commentreports.upheld', '0')
+  ->where('commentreports.user_id', '!=', 0)
+  ->groupBy('commentreports.user_id')
+  ->orderByDesc('rejectedcount')
+  ->select(['commentreports.user_id', 'u.firstname', 'u.lastname'])
+  ->selectRaw('COUNT(*) AS rejectedcount')
+  ->get();
 
 $rows = [];
 $USERURL = new URL('userview');
 
-for ($row = 0; $row < $q->rows(); $row++) {
+foreach ($rejectedReports as $report) {
 
-    $user_id = $q->field($row, 'user_id');
+    $user_id = $report->user_id;
 
     $USERURL->insert(['u' => $user_id]);
 
     // Get how many valid complaints they've submitted.
-    $r = parlDBQuery("SELECT COUNT(*) AS upheldcount
-					FROM commentreports
-					WHERE	user_id = '$user_id'
-					AND		upheld = '1'");
+    $upheldcount = Commentreport::where('user_id', $user_id)
+      ->where('upheld', '1')
+      ->count();
 
     $rows[] = [
-        '<a href="' . $USERURL->generate() . '">' . $q->field($row, 'firstname') . ' ' . $q->field($row, 'lastname') . '</a>',
-        $q->field($row, 'rejectedcount'),
-        $r->field(0, 'upheldcount')
+        '<a href="' . $USERURL->generate() . '">' . $report->firstname . ' ' . $report->lastname . '</a>',
+        $report->rejectedcount,
+        $upheldcount
     ];
 
 }

--- a/www/docs/admin/index.php
+++ b/www/docs/admin/index.php
@@ -4,6 +4,8 @@
  * @file
  */
 
+use OpenAustralia\TWFY\Models\User;
+
 include_once __DIR__ . "/../../includes/easyparliament/init.php";
 include_once __DIR__ . "/../../includes/easyparliament/commentreportlist.php";
 
@@ -17,19 +19,15 @@ $PAGE->stripe_start();
 
 $PAGE->block_start(['title' => 'Stats']);
 
-$q = parlDBQuery("SELECT COUNT(*) AS count FROM users WHERE confirmed = '1'");
-$confirmedusers = $q->field(0, 'count');
+$confirmedusers = User::where('confirmed', 1)->count();
 
-$q = parlDBQuery("SELECT COUNT(*) AS count FROM users WHERE confirmed = '0'");
-$unconfirmedusers = $q->field(0, 'count');
+$unconfirmedusers = User::where('confirmed', 0)->count();
 
 $olddate = gmdate("Y-m-d H:i:s", time() - 86400);
-$q = parlDBQuery("SELECT COUNT(*) AS count FROM users WHERE lastvisit > '$olddate'");
-$dayusers = $q->field(0, 'count');
+$dayusers = User::where('lastvisit', '>', $olddate)->count();
 
 $olddate = gmdate("Y-m-d H:i:s", time() - 86400 * 7);
-$q = parlDBQuery("SELECT COUNT(*) AS count FROM users WHERE lastvisit > '$olddate'");
-$weekusers = $q->field(0, 'count');
+$weekusers = User::where('lastvisit', '>', $olddate)->count();
 ?>
 <ul>
 <li>Confirmed users: <?php echo $confirmedusers; ?></li>
@@ -47,40 +45,33 @@ $PAGE->block_end();
 <h4>Recently registered users</h4>
 <?php
 
-$q = parlDBQuery("SELECT firstname,
-						lastname,
-						email,
-						user_id,
-						confirmed,
-						registrationtime
-				FROM	users
-				ORDER BY registrationtime DESC
-				LIMIT 50
-				");
+$recentUsers = User::orderBy('registrationtime', 'desc')
+  ->limit(50)
+  ->get(['firstname', 'lastname', 'email', 'user_id', 'confirmed', 'registrationtime']);
 
 $rows = [];
 $USERURL = new URL('userview');
 
-for ($row = 0; $row < $q->rows(); $row++) {
+foreach ($recentUsers as $user) {
 
-    $user_id = $q->field($row, 'user_id');
+    $user_id = $user->user_id;
 
     $USERURL->insert(['u' => $user_id]);
 
-    if ($q->field($row, 'confirmed') == 1) {
+    if ($user->confirmed == 1) {
         $confirmed = 'Yes';
-        $name = '<a href="' . $USERURL->generate() . '">' . htmlspecialchars($q->field($row, 'firstname'))
-        . ' ' . htmlspecialchars($q->field($row, 'lastname')) . '</a>';
+        $name = '<a href="' . $USERURL->generate() . '">' . htmlspecialchars($user->firstname)
+        . ' ' . htmlspecialchars($user->lastname) . '</a>';
     } else {
         $confirmed = 'No';
-        $name = htmlspecialchars($q->field($row, 'firstname') . ' ' . $q->field($row, 'lastname'));
+        $name = htmlspecialchars($user->firstname . ' ' . $user->lastname);
     }
 
     $rows[] = [
         $name,
-        '<a href="mailto:' . $q->field($row, 'email') . '">' . $q->field($row, 'email') . '</a>',
+        '<a href="mailto:' . $user->email . '">' . $user->email . '</a>',
         $confirmed,
-        $q->field($row, 'registrationtime')
+        $user->registrationtime
     ];
 }
 

--- a/www/docs/admin/statistics.php
+++ b/www/docs/admin/statistics.php
@@ -4,6 +4,8 @@
  * @file
  */
 
+use OpenAustralia\TWFY\Models\Hansard;
+
 include_once __DIR__ . "/../../includes/easyparliament/init.php";
 $this_page = "admin_statistics";
 
@@ -27,14 +29,11 @@ $debate_speeches = $DEBATELIST->total_speeches();
 
 $wrans_questions = $WRANSLIST->total_questions();
 
-$q = parlDBQuery("SELECT MIN(hdate) AS mindate, MAX(hdate) AS maxdate FROM hansard");
-$datefrom = format_date($q->field(0, 'mindate'), SHORTDATEFORMAT);
-$dateto = format_date($q->field(0, 'maxdate'), SHORTDATEFORMAT);
+$datefrom = format_date(Hansard::min('hdate'), SHORTDATEFORMAT);
+$dateto = format_date(Hansard::max('hdate'), SHORTDATEFORMAT);
 
-$q = parlDBQuery("SELECT COUNT(DISTINCT hdate) AS count FROM hansard");
-$uniquedates = $q->field(0, 'count');
+$uniquedates = Hansard::distinct()->count('hdate');
 ?>
-
 
 <p><b><?php echo $datefrom?></b> to <b><?php echo $dateto?></b>. Parliament was sitting for
 <b><?php echo $uniquedates?></b> of those days.

--- a/www/includes/Models/Alert.php
+++ b/www/includes/Models/Alert.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Alert Eloquent model.
+ *
+ * @property int $alert_id
+ * @property string $email
+ * @property string $criteria
+ * @property int $deleted
+ * @property string $registrationtoken
+ * @property int $confirmed
+ * @property string $created
+ * @property int $recommended
+ */
+class Alert extends Model {
+
+    protected $table = 'alerts';
+
+    protected $primaryKey = 'alert_id';
+
+    protected $fillable = [
+        'email',
+        'criteria',
+        'deleted',
+        'registrationtoken',
+        'confirmed',
+        'created',
+        'recommended',
+    ];
+
+    protected $casts = [
+        'deleted' => 'bool',
+        'confirmed' => 'bool',
+        'recommended' => 'bool',
+    ];
+
+}

--- a/www/includes/Models/Anonvote.php
+++ b/www/includes/Models/Anonvote.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Anonvote Eloquent model.
+ *
+ * @property int $epobject_id
+ * @property int $yes_votes
+ * @property int $no_votes
+ */
+class Anonvote extends Model {
+
+    protected $table = 'anonvotes';
+
+    protected $primaryKey = 'epobject_id';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'epobject_id',
+        'yes_votes',
+        'no_votes',
+    ];
+
+    protected $casts = [
+        'yes_votes' => 'int',
+        'no_votes' => 'int',
+    ];
+
+}

--- a/www/includes/Models/ApiKey.php
+++ b/www/includes/Models/ApiKey.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * ApiKey Eloquent model.
+ *
+ * @property int $id
+ * @property int $user_id
+ * @property string $api_key
+ * @property int $commercial
+ * @property string $created
+ * @property string|null $disabled
+ * @property string $reason
+ */
+class ApiKey extends Model {
+
+    protected $table = 'api_key';
+
+    protected $fillable = [
+        'user_id',
+        'api_key',
+        'commercial',
+        'created',
+        'disabled',
+        'reason',
+    ];
+
+    protected $casts = [
+        'commercial' => 'bool',
+    ];
+
+}

--- a/www/includes/Models/ApiStat.php
+++ b/www/includes/Models/ApiStat.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * ApiStat Eloquent model.
+ *
+ * @property int $id
+ * @property string $api_key
+ * @property string $ip_address
+ * @property string $query_time
+ * @property string $query
+ */
+class ApiStat extends Model {
+
+    protected $table = 'api_stats';
+
+    protected $fillable = [
+        'api_key',
+        'ip_address',
+        'query_time',
+        'query',
+    ];
+
+}

--- a/www/includes/Models/Bills.php
+++ b/www/includes/Models/Bills.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Bills Eloquent model.
+ *
+ * Maps to the bills table containing parliamentary bill/legislation information.
+ *
+ * @property int $id
+ * @property string $title
+ * @property string $url
+ * @property bool $lords
+ * @property string $session
+ * @property string $standingprefix
+ */
+class Bills extends Model {
+
+    protected $table = 'bills';
+
+    protected $primaryKey = 'id';
+
+    public $timestamps = true;
+
+    // Cast boolean fields.
+    protected $casts = [
+        'lords' => 'bool',
+    ];
+
+    // Fillable fields for mass assignment.
+    protected $fillable = [
+        'title',
+        'url',
+        'lords',
+        'session',
+        'standingprefix',
+    ];
+
+}

--- a/www/includes/Models/Commentreport.php
+++ b/www/includes/Models/Commentreport.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Commentreport Eloquent model.
+ *
+ * @property int $report_id
+ * @property int|null $comment_id
+ * @property int|null $user_id
+ * @property string|null $body
+ * @property string|null $reported
+ * @property string|null $resolved
+ * @property int|null $resolvedby
+ * @property string|null $locked
+ * @property int|null $lockedby
+ * @property int $upheld
+ * @property string|null $firstname
+ * @property string|null $lastname
+ * @property string|null $email
+ */
+class Commentreport extends Model {
+
+    protected $table = 'commentreports';
+
+    protected $primaryKey = 'report_id';
+
+    public $timestamps = true;
+
+}

--- a/www/includes/Models/Comments.php
+++ b/www/includes/Models/Comments.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Comments Eloquent model.
+ *
+ * Maps to the comments table containing user comments on hansard sections.
+ *
+ * @property int $comment_id
+ * @property int $user_id
+ * @property int $epobject_id
+ * @property string|null $body
+ * @property string|null $posted
+ * @property string|null $modflagged
+ * @property bool $visible
+ * @property string|null $original_gid
+ */
+class Comments extends Model {
+
+    protected $table = 'comments';
+
+    protected $primaryKey = 'comment_id';
+
+    public $timestamps = true;
+
+    public const CREATED_AT = 'posted';
+
+    // Cast date fields.
+    protected $casts = [
+        'posted' => 'datetime',
+        'modflagged' => 'datetime',
+        'visible' => 'bool',
+    ];
+
+    // Fillable fields for mass assignment.
+    protected $fillable = [
+        'user_id',
+        'epobject_id',
+        'body',
+        'posted',
+        'modflagged',
+        'visible',
+        'original_gid',
+    ];
+
+}

--- a/www/includes/Models/Consinfo.php
+++ b/www/includes/Models/Consinfo.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Consinfo Eloquent model.
+ *
+ * @property string $constituency
+ * @property string $data_key
+ * @property string $data_value
+ */
+class Consinfo extends Model {
+
+    protected $table = 'consinfo';
+
+    public $incrementing = false;
+
+    protected $primaryKey = null;
+
+    protected $fillable = [
+        'constituency',
+        'data_key',
+        'data_value',
+    ];
+
+}

--- a/www/includes/Models/Constituency.php
+++ b/www/includes/Models/Constituency.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Constituency Eloquent model — READ-ONLY.
+ *
+ * Maps to the constituency table containing parliamentary constituency information.
+ *
+ * IMPORTANT: This table has NO PRIMARY KEY defined in the schema.
+ *
+ * Data flows one direction: openaustralia-parser → scripts/xml2db.pl → database
+ * The PHP codebase is READ-ONLY for this table in production.
+ *
+ * Data pipeline:
+ * 1. openaustralia-parser (Ruby, ../openaustralia-parser/)
+ *    - Parses Hansard transcripts and generates structured member/division data
+ *    - Writes constituency data to XML output
+ *    - See: openaustralia-parser/lib/parser/ and openaustralia-parser/lib/xml_generators/
+ * 2. scripts/xml2db.pl (Perl)
+ *    - Reads the XML output from openaustralia-parser
+ *    - Deletes all existing constituencies
+ *    - Re-inserts them from XML data during updates
+ *    - Runs via scripts/update-hansard.pl
+ *
+ * NOTE: Tests may create fixture data using this model for testing purposes.
+ *
+ * @property string $name
+ * @property bool $main_name
+ * @property string $from_date
+ * @property string $to_date
+ * @property int|null $cons_id
+ */
+class Constituency extends Model {
+
+    protected $table = 'constituency';
+
+    public $timestamps = true;
+
+    // Prevent mass assignment to protect read-only status.
+    protected $guarded = ['*'];
+
+    // Cast date fields.
+    protected $casts = [
+        'from_date' => 'date',
+        'to_date' => 'date',
+        'main_name' => 'bool',
+    ];
+
+}

--- a/www/includes/Models/Editqueue.php
+++ b/www/includes/Models/Editqueue.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Editqueue Eloquent model.
+ *
+ * @property int $edit_id
+ * @property int|null $user_id
+ * @property int|null $edit_type
+ * @property int|null $epobject_id_l
+ * @property int|null $epobject_id_h
+ * @property int|null $glossary_id
+ * @property string|null $time_start
+ * @property string|null $time_end
+ * @property string|null $title
+ * @property string|null $body
+ * @property string|null $submitted
+ * @property int|null $editor_id
+ * @property int|null $approved
+ * @property string|null $decided
+ * @property string|null $reason
+ */
+class Editqueue extends Model {
+
+    protected $table = 'editqueue';
+
+    protected $primaryKey = 'edit_id';
+
+    protected $fillable = [
+        'user_id',
+        'edit_type',
+        'epobject_id_l',
+        'epobject_id_h',
+        'glossary_id',
+        'time_start',
+        'time_end',
+        'title',
+        'body',
+        'submitted',
+        'editor_id',
+        'approved',
+        'decided',
+        'reason',
+    ];
+
+    protected $casts = [
+        'approved' => 'bool',
+    ];
+
+}

--- a/www/includes/Models/Epobject.php
+++ b/www/includes/Models/Epobject.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Epobject Eloquent model.
+ *
+ * @property int $epobject_id
+ * @property string|null $title
+ * @property string|null $body
+ * @property int|null $type
+ * @property string|null $created
+ * @property string|null $modified
+ */
+class Epobject extends Model {
+
+    protected $table = 'epobject';
+
+    protected $primaryKey = 'epobject_id';
+
+    public $timestamps = true;
+
+    protected $fillable = [
+        'epobject_id',
+        'title',
+        'body',
+        'type',
+        'created',
+        'modified',
+    ];
+
+}

--- a/www/includes/Models/Gidredirect.php
+++ b/www/includes/Models/Gidredirect.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Gidredirect Eloquent model.
+ *
+ * @property string|null $gid_from
+ * @property string|null $gid_to
+ * @property string $hdate
+ * @property int|null $major
+ */
+class Gidredirect extends Model {
+
+    protected $table = 'gidredirect';
+
+    public $incrementing = false;
+
+    protected $primaryKey = 'gid_from';
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'gid_from',
+        'gid_to',
+        'hdate',
+        'major',
+    ];
+
+    protected $casts = [
+        'hdate' => 'date',
+    ];
+
+}

--- a/www/includes/Models/Glossary.php
+++ b/www/includes/Models/Glossary.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Glossary Eloquent model.
+ *
+ * @property int $glossary_id
+ * @property string|null $title
+ * @property string|null $body
+ * @property string|null $wikipedia
+ * @property string|null $created
+ * @property string|null $last_modified
+ * @property int|null $type
+ * @property int|null $visible
+ */
+class Glossary extends Model {
+
+    protected $table = 'glossary';
+
+    protected $primaryKey = 'glossary_id';
+
+    protected $fillable = [
+        'title',
+        'body',
+        'wikipedia',
+        'created',
+        'last_modified',
+        'type',
+        'visible',
+    ];
+
+    protected $casts = [
+        'visible' => 'bool',
+    ];
+
+}

--- a/www/includes/Models/Hansard.php
+++ b/www/includes/Models/Hansard.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Hansard Eloquent model.
+ *
+ * Maps to the hansard table containing parliamentary speech/debate records.
+ *
+ * @property int $epobject_id
+ * @property string|null $gid
+ * @property int $htype
+ * @property int $speaker_id
+ * @property int $major
+ * @property int $section_id
+ * @property int $subsection_id
+ * @property int $hpos
+ * @property string $hdate
+ * @property string|null $htime
+ * @property string $source_url
+ * @property int|null $minor
+ * @property string|null $created
+ * @property string|null $modified
+ */
+class Hansard extends Model {
+
+    protected $table = 'hansard';
+
+    protected $primaryKey = 'epobject_id';
+
+    // Primary key is not auto-increment.
+    public $incrementing = false;
+
+    public $timestamps = true;
+
+    // Cast date fields.
+    protected $casts = [
+        'hdate' => 'date',
+        'created' => 'datetime',
+        'modified' => 'datetime',
+    ];
+
+    // Fillable fields for mass assignment.
+    protected $fillable = [
+        'epobject_id',
+        'gid',
+        'htype',
+        'speaker_id',
+        'major',
+        'section_id',
+        'subsection_id',
+        'hpos',
+        'hdate',
+        'htime',
+        'source_url',
+        'minor',
+        'created',
+        'modified',
+    ];
+
+}

--- a/www/includes/Models/Indexbatch.php
+++ b/www/includes/Models/Indexbatch.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Indexbatch Eloquent model.
+ *
+ * @property int $indexbatch_id
+ * @property string|null $created
+ */
+class Indexbatch extends Model {
+
+    protected $table = 'indexbatch';
+
+    protected $primaryKey = 'indexbatch_id';
+
+    protected $fillable = [
+        'created',
+    ];
+
+}

--- a/www/includes/Models/Memberinfo.php
+++ b/www/includes/Models/Memberinfo.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Memberinfo Eloquent model.
+ *
+ * @property int $member_id
+ * @property string $data_key
+ * @property string $data_value
+ * @property string $lastupdate
+ */
+class Memberinfo extends Model {
+
+    protected $table = 'memberinfo';
+
+    public $incrementing = false;
+
+    protected $primaryKey = null;
+
+    protected $fillable = [
+        'member_id',
+        'data_key',
+        'data_value',
+    ];
+
+}

--- a/www/includes/Models/Mention.php
+++ b/www/includes/Models/Mention.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Mention Eloquent model.
+ *
+ * @property int $mention_id
+ * @property string|null $gid
+ * @property int $type
+ * @property string|null $date
+ * @property string|null $url
+ * @property string|null $mentioned_gid
+ */
+class Mention extends Model {
+
+    protected $table = 'mentions';
+
+    protected $primaryKey = 'mention_id';
+
+    protected $fillable = [
+        'gid',
+        'type',
+        'date',
+        'url',
+        'mentioned_gid',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+    ];
+
+}

--- a/www/includes/Models/Moffice.php
+++ b/www/includes/Models/Moffice.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Eloquent model for the `moffice` table.
+ *
+ * The primary key is `moffice_id`. This is a legacy table without Eloquent's
+ * managed timestamp columns.
+ */
+class Moffice extends Model {
+
+    /**
+     * @var string
+     */
+    protected $table = 'moffice';
+
+    /**
+     * @var string
+     */
+    protected $primaryKey = 'moffice_id';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = true;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'dept',
+        'position',
+        'from_date',
+        'to_date',
+        'person',
+        'source',
+    ];
+
+    /**
+     * @var array<string,string>
+     */
+    protected $casts = [
+        'moffice_id' => 'int',
+        'person'     => 'int',
+        'from_date'  => 'date',
+        'to_date'    => 'date',
+    ];
+
+}

--- a/www/includes/Models/PbcMember.php
+++ b/www/includes/Models/PbcMember.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * PbcMember Eloquent model.
+ *
+ * @property int $id
+ * @property int $member_id
+ * @property int $chairman
+ * @property int $bill_id
+ * @property string $sitting
+ * @property int $attending
+ */
+class PbcMember extends Model {
+
+    protected $table = 'pbc_members';
+
+    protected $fillable = [
+        'member_id',
+        'chairman',
+        'bill_id',
+        'sitting',
+        'attending',
+    ];
+
+    protected $casts = [
+        'chairman' => 'bool',
+        'attending' => 'bool',
+    ];
+
+}

--- a/www/includes/Models/Personinfo.php
+++ b/www/includes/Models/Personinfo.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Personinfo Eloquent model.
+ *
+ * @property int $person_id
+ * @property string $data_key
+ * @property string $data_value
+ * @property string $lastupdate
+ */
+class Personinfo extends Model {
+
+    protected $table = 'personinfo';
+
+    public $incrementing = false;
+
+    protected $primaryKey = null;
+
+    protected $fillable = [
+        'person_id',
+        'data_key',
+        'data_value',
+    ];
+
+}

--- a/www/includes/Models/PostcodeLookup.php
+++ b/www/includes/Models/PostcodeLookup.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * PostcodeLookup Eloquent model.
+ *
+ * Maps to the postcode_lookup table containing postcode to constituency mappings.
+ *
+ * @property string $postcode
+ * @property string $name
+ */
+class PostcodeLookup extends Model {
+
+    protected $table = 'postcode_lookup';
+
+    public $incrementing = false;
+
+    protected $primaryKey = null;
+
+    protected $fillable = [
+        'postcode',
+        'name',
+    ];
+
+}

--- a/www/includes/Models/SearchQueryLog.php
+++ b/www/includes/Models/SearchQueryLog.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * SearchQueryLog Eloquent model.
+ *
+ * @property int $id
+ * @property string|null $query_string
+ * @property int|null $page_number
+ * @property int|null $count_hits
+ * @property string|null $ip_address
+ * @property string|null $query_time
+ */
+class SearchQueryLog extends Model {
+
+    protected $table = 'search_query_log';
+
+    public $timestamps = true;
+
+    protected $fillable = [
+        'query_string',
+        'page_number',
+        'count_hits',
+        'ip_address',
+        'query_time',
+    ];
+
+}

--- a/www/includes/Models/Title.php
+++ b/www/includes/Models/Title.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Title Eloquent model.
+ *
+ * @property string $title
+ */
+class Title extends Model {
+
+    protected $table = 'titles';
+
+    protected $primaryKey = 'title';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    protected $fillable = [
+        'title',
+    ];
+
+}

--- a/www/includes/Models/Uservotes.php
+++ b/www/includes/Models/Uservotes.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Uservotes Eloquent model.
+ *
+ * Maps to the uservotes table containing user votes/ratings on hansard sections.
+ *
+ * @property int $user_id
+ * @property int $epobject_id
+ * @property int $vote
+ */
+class Uservotes extends Model {
+
+    protected $table = 'uservotes';
+
+    // No primary key - this is a bridge/junction table.
+    public $timestamps = true;
+    public $incrementing = false;
+
+    // Cast vote as boolean-ish (0 or 1)
+    protected $casts = [
+        'vote' => 'int',
+    ];
+
+    // Fillable fields for mass assignment.
+    protected $fillable = [
+        'user_id',
+        'epobject_id',
+        'vote',
+    ];
+
+}

--- a/www/includes/Models/VideoTimestamp.php
+++ b/www/includes/Models/VideoTimestamp.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OpenAustralia\TWFY\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * VideoTimestamp Eloquent model.
+ *
+ * @property int $id
+ * @property string $gid
+ * @property int|null $user_id
+ * @property string $atime
+ * @property int $deleted
+ * @property string $whenstamped
+ */
+class VideoTimestamp extends Model {
+
+    protected $table = 'video_timestamps';
+
+    protected $fillable = [
+        'gid',
+        'user_id',
+        'atime',
+        'deleted',
+    ];
+
+    protected $casts = [
+        'deleted' => 'bool',
+    ];
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
part of
 - https://github.com/openaustralia/openaustralia/issues/884

## Motivation and Context
Convert queries in the admin to use our models/orm

This mean keeping our SQL compatible with modern databases is the responsiblity of the ORM, not our code


## How Has This Been Tested?
tested in docker/local

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
