### PR TITLE
chore: upgrade MySQL version to 8.4 in workflows and documentation

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,7 +40,7 @@ jobs:
       pull-requests: write
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: test_twfy
@@ -110,7 +110,7 @@ jobs:
       pull-requests: write
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: test_twfy
@@ -156,7 +156,7 @@ jobs:
           DB_NAME: test_twfy
       - name: Dump schema from migrated database
         run: |
-          docker run --rm --network host mysql:8.0 mysqldump \
+          docker run --rm --network host mysql:8.4 mysqldump \
             --host=127.0.0.1 --protocol=TCP \
             --user=root --password=root \
             --no-data --skip-comments --skip-add-drop-table --skip-set-charset \

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Stop everything with `docker compose down`.
 
 ### MySQL version
 
-We run **MySQL 8.0** in production (currently 8.0.44). The `mysql:8.0`
+We run **MySQL 8.4** in production. The `mysql:8.4`
 image is pinned in [`docker-compose.yml`](docker-compose.yml) and in the
 GitHub Actions workflow (`.github/workflows/php.yml`) so local
 development, CI and production stay aligned. Schema dumps from

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ../phplib:/phplib
       - ./_xapiandb:/app/shared/search
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     ports:
       - "${TWFY_MYSQL_PORT:-3306}:3306"
     networks:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
part of:
 - https://github.com/openaustralia/openaustralia/issues/884
 
## Description

Switch Docker, tests, and documentation to refer toMySQL 8.44

## Motivation and Context
So we can upgrade production

## How Has This Been Tested?
Running CI will be the first testing.
