### PR TITLE
Rewrite and reposition the "What's all this about?" home page box

### DIFF
--- a/tests/IndexPageIntegrationTest.php
+++ b/tests/IndexPageIntegrationTest.php
@@ -19,4 +19,13 @@ class IndexPageIntegrationTest extends PageRenderingIntegrationTestCase {
         $this->assertPageRenders(__DIR__ . '/../www/docs/index.php', 'desktop');
     }
 
+    /**
+     * Test that the "What's all this about?" box is rendered on the home page.
+     */
+    public function test_index_page_shows_what_is_this_site_box(): void {
+        $output = $this->assertPageRenders(__DIR__ . '/../www/docs/index.php', 'desktop');
+        $this->assertStringContainsString("What's all this about?", $output);
+        $this->assertStringContainsString('public digital online library', $output);
+    }
+
 }

--- a/tests/MobilePageIntegrationTest.php
+++ b/tests/MobilePageIntegrationTest.php
@@ -19,4 +19,13 @@ class MobilePageIntegrationTest extends PageRenderingIntegrationTestCase {
         $this->assertPageRenders(__DIR__ . '/../www/docs/mobile.php', 'mobile');
     }
 
+    /**
+     * Test that the "What's all this about?" box is rendered on the mobile home page.
+     */
+    public function test_mobile_page_shows_what_is_this_site_box(): void {
+        $output = $this->assertPageRenders(__DIR__ . '/../www/docs/mobile.php', 'mobile');
+        $this->assertStringContainsString("What's all this about?", $output);
+        $this->assertStringContainsString('public digital online library', $output);
+    }
+
 }

--- a/www/docs/index.php
+++ b/www/docs/index.php
@@ -22,6 +22,10 @@ if ($message != '') {
 
 $HANSARDURL = new URL('hansard');
 $MPURL = new URL('yourmp');
+
+// Explain what the site is before offering the search tools.
+$PAGE->include_sidebar_template('whatisthissite');
+
 $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']);
 ?>
 <ol>
@@ -51,7 +55,7 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
                 }
                 ?>
                 <p><a href="<?php echo $MPURL->generate(); ?>"><strong>Find out more about <?php echo $mpname; ?>, your
-                            <?php echo $former ?> Representative</strong></a>
+                            <?php echo $former ?> Federal Representative</strong></a>
                     (<a href="<?php echo $CHANGEURL->generate(); ?>">Change</a>)</p>
                 <?php
             }
@@ -59,7 +63,7 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
 
         if ($pc_form) { ?>
             <form action="<?php echo $MPURL->generate(); ?>" method="get">
-                <p><strong>Find out more about your Representative</strong><br>
+                <p><strong>Find out more about your Federal Representative</strong><br>
                     <label for="pc">Enter your Australian postcode here:</label>&nbsp; <input type="text" name="pc" id="pc"
                         size="8" maxlength="10" class="text">&nbsp;&nbsp;<input type="submit" value=" GO " class="submit">
                 </p>
@@ -190,11 +194,5 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
 <?php
 $PAGE->block_end();
 
-$includes = [
-    [
-        'type' => 'include',
-        'content' => 'whatisthissite'
-    ]
-];
-$PAGE->stripe_end($includes);
+$PAGE->stripe_end();
 $PAGE->page_end();

--- a/www/docs/mobile.php
+++ b/www/docs/mobile.php
@@ -64,7 +64,7 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
 
         if ($pc_form) { ?>
             <form action="<?php echo $MPURL->generate(); ?>" method="get">
-                <p><strong>Find out about the Federal Representative for your postcode:</strong>
+                <p><strong><label for="pc">Find out about the Federal Representative for your postcode:</label></strong>
                     <input type="text" name="pc" id="pc" size="10" maxlength="10" class="text">&nbsp;&nbsp;<input type="submit"
                         value=" GO " class="submit">
                 </p>

--- a/www/docs/mobile.php
+++ b/www/docs/mobile.php
@@ -24,6 +24,10 @@ if ($message != '') {
 
 $HANSARDURL = new URL('hansard');
 $MPURL = new URL('yourmp');
+
+// Explain what the site is before offering the search tools.
+$PAGE->include_sidebar_template('whatisthissite');
+
 $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']);
 ?>
 <ol>
@@ -52,7 +56,7 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
                 }
                 ?>
                 <p><a href="<?php echo $MPURL->generate(); ?>"><strong>Find out more about <?php echo $mpname; ?>, your
-                            <?php echo $former ?> Representative</strong></a>
+                            <?php echo $former ?> Federal Representative</strong></a>
                     (<a href="<?php echo $CHANGEURL->generate(); ?>">Change</a>)</p>
                 <?php
             }
@@ -60,7 +64,7 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
 
         if ($pc_form) { ?>
             <form action="<?php echo $MPURL->generate(); ?>" method="get">
-                <p><strong>Find out about the Representative for your postcode:</strong>
+                <p><strong>Find out about the Federal Representative for your postcode:</strong>
                     <input type="text" name="pc" id="pc" size="10" maxlength="10" class="text">&nbsp;&nbsp;<input type="submit"
                         value=" GO " class="submit">
                 </p>
@@ -191,11 +195,5 @@ $PAGE->block_start(['id' => 'intro', 'title' => 'At OpenAustralia.org you can:']
 <?php
 $PAGE->block_end();
 
-$includes = [
-    [
-        'type' => 'include',
-        'content' => 'whatisthissite'
-    ]
-];
-
+$PAGE->stripe_end();
 $PAGE->page_end_mobile();

--- a/www/docs/style/default/global_non_ns4.css
+++ b/www/docs/style/default/global_non_ns4.css
@@ -938,7 +938,7 @@ ul#dreamcomparisons {
 	margin-bottom: 1em;
 }
 
-acronym {
+abbr {
 	border-bottom: dotted 1px black;
 }
 

--- a/www/docs/style/default/global_non_ns4.css
+++ b/www/docs/style/default/global_non_ns4.css
@@ -471,9 +471,14 @@ div#help.block h4 {
 div#help.block h4 a {
 	color: #fff;
 	}
-	
-	
-	
+/* On the home page this box sits in the main column rather than the sidebar,
+   so it needs the heading background that div.sidebar div.block h4 supplies. */
+div.main div#help.block h4 {
+	background: #A8A98C; /* NAT */
+	}
+
+
+
 /**** SIDEBARS ******************************************************************/
 
 div.sidebar {

--- a/www/docs/style/default/global_non_ns4.css
+++ b/www/docs/style/default/global_non_ns4.css
@@ -938,7 +938,7 @@ ul#dreamcomparisons {
 	margin-bottom: 1em;
 }
 
-abbr {
+acronym {
 	border-bottom: dotted 1px black;
 }
 

--- a/www/docs/style/default/global_non_ns4_mobile.css
+++ b/www/docs/style/default/global_non_ns4_mobile.css
@@ -470,9 +470,14 @@ div#help.block h4 {
 div#help.block h4 a {
 	color: #fff;
 	}
-	
-	
-	
+/* On the home page this box sits in the main column rather than the sidebar,
+   so it needs the heading background that div.sidebar div.block h4 supplies. */
+div.main div#help.block h4 {
+	background: #A8A98C; /* NAT */
+	}
+
+
+
 /**** SIDEBARS ******************************************************************/
 
 div.sidebar {

--- a/www/docs/style/default/global_non_ns4_mobile.css
+++ b/www/docs/style/default/global_non_ns4_mobile.css
@@ -937,7 +937,7 @@ ul#dreamcomparisons {
 	margin-bottom: 1em;
 }
 
-abbr {
+acronym {
 	border-bottom: dotted 1px black;
 }
 

--- a/www/docs/style/default/global_non_ns4_mobile.css
+++ b/www/docs/style/default/global_non_ns4_mobile.css
@@ -937,7 +937,7 @@ ul#dreamcomparisons {
 	margin-bottom: 1em;
 }
 
-acronym {
+abbr {
 	border-bottom: dotted 1px black;
 }
 

--- a/www/includes/easyparliament/sidebars/whatisthissite.php
+++ b/www/includes/easyparliament/sidebars/whatisthissite.php
@@ -9,22 +9,23 @@ $this->block_start(['id' => 'help', 'title' => "What's all this about?"]);
 
 $URL = new URL('about');
 $abouturl = $URL->generate();
-
-$URL = new URL('help');
-$helpurl = $URL->generate();
 ?>
 
+<p><strong>Hansard, made findable.</strong> Searchable transcripts of Australian Federal Parliament.</p>
+
+<p><a href="<?php echo $abouturl; ?>" title="link to About Us page">OpenAustralia.org.au</a> is an independent
+    collection of Hansard, the official record of the Australian Federal Parliament. The Hansard library at
+    OpenAustralia.org.au is stored as a machine-readable and searchable repository, providing democratic open access to
+    Australia's legislative systems.</p>
+
+<p>The <a href="https://www.oaf.org.au">OpenAustralia Foundation</a> is a public digital online library; independent and
+    strictly non-partisan. As a <a
+        href="https://www.acnc.gov.au/charity/55c2c06e21ac71e9359a0590b9fc100e">registered charity</a>, it is powered by
+    donations from people like you.</p>
+
 <p><a href="https://donate.oaf.org.au/">
-        <img src="<?php echo IMAGEPATH . "donate_greenL.png" ?>" width="108" height="43" border="0" align="right"
-            hspace="4" vspace="5" alt="Donate"></a>
-    <a href="<?php echo $abouturl; ?>" title="link to About Us page">OpenAustralia.org</a> is a
-    non-partisan website run by a charity, the <a href="https://www.oaf.org.au">OpenAustralia
-        Foundation</a>. It aims to make it easy for people to keep tabs on their
-    representatives in Parliament.
+        <img src="<?php echo IMAGEPATH . "donate_greenL.png" ?>" width="108" height="43" alt="Donate"></a>
 </p>
-<p>The OpenAustralia Foundation is a public digital online library. It is an independent, strictly non-partisan <a
-        href="https://www.acnc.gov.au/charity/55c2c06e21ac71e9359a0590b9fc100e">charity</a>, powered by donations from
-    people like you.</p>
 
 <?php
 $this->block_end();

--- a/www/includes/easyparliament/sidebars/whatisthissite.php
+++ b/www/includes/easyparliament/sidebars/whatisthissite.php
@@ -11,7 +11,7 @@ $URL = new URL('about');
 $abouturl = $URL->generate();
 ?>
 
-<p><strong>Hansard, made findable.</strong> Searchable transcripts of Australian Federal Parliament.</p>
+<p><strong>Hansard, made findable.</strong> Searchable transcripts of the Australian Federal Parliament.</p>
 
 <p><a href="<?php echo $abouturl; ?>" title="link to About Us page">OpenAustralia.org.au</a> is an independent
     collection of Hansard, the official record of the Australian Federal Parliament. The Hansard library at


### PR DESCRIPTION
## Description

Rewrites the "What's all this about?" box on the OpenAustralia.org.au home page and moves it above the search tools.

- **New copy** in `www/includes/easyparliament/sidebars/whatisthissite.php`: opens with the Hansard strapline ("Hansard, made findable. Searchable transcripts of the Australian Federal Parliament."), then the two paragraphs agreed in the issue. Existing links are kept: the site name still links to About, "OpenAustralia Foundation" to oaf.org.au, and "registered charity" to the ACNC record.
- **Donate link moved below the paragraphs** rather than floated inside the first one, and the presentational HTML4 attributes that only made sense while it floated (`align`, `hspace`, `vspace`, `border`) are dropped. Same URL, same image.
- **The box now renders in the main column above the search tools**, on `www/docs/index.php` and `www/docs/mobile.php`, via the existing `PAGE::include_sidebar_template()`. The `$includes` array each page passed to `stripe_end()` is gone.
- **Fixes the box never appearing on the mobile home page.** `mobile.php` built the `$includes` array but called `page_end_mobile()` without ever calling `stripe_end()`, so the box was never output and `div.main` and `div.stripe-side` were left unclosed. `mobile.php` now calls `stripe_end()`.
- **CSS:** the box's heading text is white, and the background behind it came from `div.sidebar div.block h4`. Outside the sidebar that rule doesn't apply, so the heading would have been white on cream. Added `div.main div#help.block h4 { background: #A8A98C }` to both `global_non_ns4.css` and `global_non_ns4_mobile.css`. Scoped to `div.main` so it doesn't touch the 20-odd other sidebar partials that reuse `id="help"`.
- **Federal scope made explicit** on both home pages: the postcode lookup now says "Federal Representative".
- **Gave the mobile postcode input a label.** `index.php` wraps its equivalent prompt in `<label for="pc">`; `mobile.php` never did, so the field had no accessible name. Picked up in review because the prompt is a line this branch changes.
- **Tests:** added an assertion to `IndexPageIntegrationTest` and `MobilePageIntegrationTest` that the box's heading and copy are present, so it silently disappearing from either home page fails a test.

`404.php`, `gadget/index.php` and `index-election.php` are untouched. They keep the box in the sidebar and pick up the new copy automatically.

A deprecated-CSS-selector change was made and then reverted during review (485ace8), so it is no longer part of this branch. See the comments for why.

## Motivation and Context

Part of the copy review across our services. Resolves openaustralia/openaustralia#899.

The old copy said the site "aims to make it easy for people to keep tabs on their representatives in Parliament" without saying what the site actually holds. The new copy says plainly that it's a searchable collection of federal Hansard, and spells out what Hansard is for people who don't know the word.

The box also wasn't reaching people on mobile at all, which is the structural half of the issue.

Two things deliberately left out of scope, both flagged on the issue:

- `www/includes/easyparliament/staticpages/about.php` carries near-duplicate copy that will now differ in tone. The issue covers the home page only; this belongs in the rest-of-site pass.
- "Representative", "MP" and similar recur across other templates. Adding "Federal" everywhere is a sweep beyond the home page.

## How Has This Been Tested?

- [ ] Checked affected area manually on my own / staging system
- [x] Ran automated tests on my own system
- [x] Confirmed it passed the GitHub actions tests

Every check in `.github/workflows` passes: `lint`, `test`, `Schema in git matches migrations`, both CodeQL analyses and both Socket checks. Locally, `make lint-php-ci`, `make phpcs-ci` (75/75) and `composer validate` are clean, and the two home page integration tests pass (4 tests, 24 assertions). I checked the mobile assertion against the old `mobile.php` and it fails there, so it does catch the bug.

The SonarCloud quality gate still fails. New-code coverage can't be measured for pages that the test harness deliberately runs in a separate process, and new-code duplication is unavoidable because `index.php` lines 14-86 and `mobile.php` lines 16-86 are already a single 71-line duplicate block. Details in the comments.

**The manual browser check has not been done - I have no Docker daemon, so I couldn't do it.** What to look at:

1. `/` - box sits above "At OpenAustralia.org you can:", heading legible, strapline and both paragraphs read as agreed, postcode form says "your Federal Representative", Donate image below the text linking to `https://donate.oaf.org.au/`.
2. `/mobile.php` - box renders above the search tools, and view source to confirm `div.main`, `div.sidebar` and `div.stripe-side` all close.
3. A 404 page and `/gadget/` - box still renders in the sidebar with the new copy and unchanged styling.

## Screenshots (if appropriate):

Not captured - no way to run the site in this environment. Worth attaching a before/after of the home page and the mobile home page.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhGqsKcyTvBa4dm1ty9KmC