### PR TITLE
Add AGENTS.md for AI coding agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot instructions
+
+See [AGENTS.md](../AGENTS.md) for repository guidance. It applies here too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, GitHub Copilot, and others) when working with code in
+this repository. `CLAUDE.md` and `.github/copilot-instructions.md` point here so the guidance lives in one place.
+
+## What this repository is
+
+The PHP web application behind OpenAustralia.org.au - a fork of mySociety's 2001-era TheyWorkForYou, repurposed for
+Australia. PHP 8.3 (`composer.json`, `mise.toml`), MySQL 8.4, Apache, Xapian search. Most of the app is legacy
+include-style PHP under `www/includes/easyparliament/` with globals and constants, plus a newer namespaced corner
+(`OpenAustralia\TWFY\` maps to `www/includes/`, Eloquent models in `www/includes/Models/`). Expect 2001-era idioms;
+match the file you're in, don't modernise in passing.
+
+It is consumed as a git submodule of [`openaustralia/openaustralia`](https://github.com/openaustralia/openaustralia)
+(the umbrella repository), which owns deployment. Sibling repos are wired in by **relative filesystem path**, not
+Composer: `../phplib` (a handful of includes: auth, rabx, mapit, tracking), `../perllib` (`use lib` in
+`search/index.pl` and the `scripts/*.pl` cron scripts), `../openaustralia-parser` (cron scripts and the postcode
+seeder), `../shlib` (shellcheck CI). Docker mounts `../phplib`; CI checks siblings out and symlinks them, matching
+your branch name in the sibling repo if one exists.
+
+## Setup
+
+```
+cp conf/general-example.local-dev conf/general
+make dependencies         # composer install
+make docker               # build (slow, --no-cache, amd64) and start webhost + mysql:8.4
+make docker-db-migrate
+make docker-db-seed
+make xapian-index-docker
+```
+
+`conf/general` is gitignored and required. Note the container reads `conf/general-docker`, not your `conf/general`;
+host-side tools (phinx, phpunit) read `conf/general` or the `DB_*` environment variables, which win over the
+constants (`phinx.php`). Ports are overridable with `TWFY_HTTP_PORT` / `TWFY_MYSQL_PORT`.
+
+## Commands
+
+```
+make help                 # target list (but see gotcha below)
+make lint                 # php -l and perl -c sweeps
+make phpcs                # phpcs (Drupal standard, phpcs.xml) over www and scripts
+./vendor/bin/phpcbf <files>
+make test                 # phpunit unit tests (*Test.php)
+make test-all             # phpunit including *IntegrationTest.php - needs the docker MySQL up
+make test-coverage-docker # tests with coverage inside docker
+make docker-dump-schema   # regenerate db/schema.sql after migrating
+```
+
+CI (`.github/workflows/php.yml`) runs lint + phpcs + `composer audit`, then the test suite against MySQL 8.4 with
+SonarCloud, then a **schema-check** job that migrates a fresh database and diffs the dump against `db/schema.sql`.
+`perl.yml` and `shellcheck.yml` lint the Perl and cron-shell scripts against the sibling checkouts.
+
+## Gotchas
+
+- **`make test-docker` doesn't exist** even though `README.md` and `make help` mention it; the real target is
+  `make test-coverage-docker`.
+- **Migrations are dual-tracked.** After any Phinx migration, `db/schema.sql` must be regenerated
+  (`make docker-dump-schema`) and committed, or the schema-check CI job fails. `make docker-db-migrate` does this
+  for you. Keep MySQL pinned at 8.4 everywhere - `mysqldump` output is version-sensitive and drift shows up as
+  spurious schema diffs.
+- **Three sets of DB credentials** exist (`conf/general-example.local-dev`, `docker-compose.yml`,
+  `conf/general-docker`); the `docker-*` targets pass `DB_*` env vars so migrations work regardless, but don't
+  "unify" them.
+- **`INSTALL.txt` is mostly 2008-vintage** (PHP 4, Apache 1.3); only its Phinx section is current. Its one live
+  warning: `db/schema.sql` is history captured by the initial migration - never import it directly.
+- `_mysqldata/` and `_xapiandb/` are live Docker volume data on the host, gitignored - don't clean them out to fix
+  a problem. Xapian search is only active when `XAPIANDB` is non-empty in `conf/general` (the local-dev example
+  leaves it off, falling back to MySQL search).
+- Tests: `*Test.php` are unit tests, `*IntegrationTest.php` need the database; `tests/bootstrap.php` wraps each
+  test in mysqli and Eloquent transactions rolled back in `tearDown`, and defines the constants the legacy code
+  expects. Seeders are idempotent and `SEEDER=<Name>` runs one.
+- Psalm is configured (`psalm.xml`) but nothing runs it; phpcs (Drupal standard with K&R braces and lowercase
+  constants) is the enforced style gate.
+
+## Contributing
+
+This repository has no `CONTRIBUTING.md` or templates of its own; the org-wide ones in
+[`openaustralia/.github`](https://github.com/openaustralia/.github) apply. Fetch the current versions rather than
+relying on a copy:
+
+`gh api repos/openaustralia/.github/contents/.github/CONTRIBUTING.md -H "Accept: application/vnd.github.raw"`
+
+`gh api repos/openaustralia/.github/contents/AGENTS.md -H "Accept: application/vnd.github.raw"`
+
+A change that touches a sibling repo (most often `phplib`) needs a branch of the same name there so CI pairs them
+up. After merging here, the umbrella repository's submodule pointer needs bumping before a deploy picks it up.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,12 @@ This repository has no `CONTRIBUTING.md` or templates of its own; the org-wide o
 [`openaustralia/.github`](https://github.com/openaustralia/.github) apply. Fetch the current versions rather than
 relying on a copy:
 
-`gh api repos/openaustralia/.github/contents/.github/CONTRIBUTING.md -H "Accept: application/vnd.github.raw"`
+`curl -fsSL https://raw.githubusercontent.com/openaustralia/.github/main/.github/CONTRIBUTING.md`
 
-`gh api repos/openaustralia/.github/contents/AGENTS.md -H "Accept: application/vnd.github.raw"`
+`curl -fsSL https://raw.githubusercontent.com/openaustralia/.github/main/AGENTS.md`
+
+Any equivalent fetch of those URLs works (web fetch, or `gh api` if the GitHub CLI
+is installed); don't assume a particular tool is present.
 
 A change that touches a sibling repo (most often `phplib`) needs a branch of the same name there so CI pairs them
 up. After merging here, the umbrella repository's submodule pointer needs bumping before a deploy picks it up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

Adds AGENTS.md documenting the app: the legacy-plus-modern code split, sibling-repo wiring by relative path (phplib, perllib, openaustralia-parser, shlib) including the same-branch-name CI pairing, docker-compose setup and real Makefile targets, the dual-tracked schema rule, and the traps: make test-docker does not exist, three DB credential sets, INSTALL.txt is mostly 2008-vintage, and _mysqldata/_xapiandb are live volumes.

Part of an org-wide pass standardising agent-instruction files: canonical content in AGENTS.md, CLAUDE.md and .github/copilot-instructions.md as pointers, org rules referenced via live fetch rather than copied (see openaustralia/.github#14).

## Motivation and Context

Agents (and new contributors) had no starting context in this repo; every claim in the new file was verified against the actual files rather than inherited from memory or older docs.

## How Has This Been Tested?

- [x] I have checked the affected area on my own system - documentation only; commands and file claims verified against the repository contents
- [ ] I have run relevant automated tests on my own system
- [ ] I have confirmed it passed the GitHub actions tests

## Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

---

AI disclosure: written with Claude Code (model claude-fable-5), reviewed by a human before merge.