### PR TITLE
Add agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,22 @@ is installed); don't assume a particular tool is present.
 
 A change that touches a sibling repo (most often `phplib`) needs a branch of the same name there so CI pairs them
 up. After merging here, the umbrella repository's submodule pointer needs bumping before a deploy picks it up.
+
+## Agent skills
+
+Configuration the engineering skills read. These files describe how this repo works; edit them directly rather
+than re-running the setup skill.
+
+### Issue tracker
+
+Issues live as GitHub issues in the umbrella repo, `openaustralia/openaustralia` — issues are disabled on this
+repo. Driven by the `gh` CLI with `-R openaustralia/openaustralia`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The default five-label vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`.
+See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` and one `docs/adr/` at the root, both created lazily. See `docs/agents/domain.md`.

--- a/composer.lock
+++ b/composer.lock
@@ -6884,16 +6884,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -6959,7 +6959,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,52 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`AGENTS.md`** at the repo root. It is the canonical guidance for this repo; `CLAUDE.md` only points at it.
+- **`CONTEXT.md`** at the repo root, if it exists.
+- **`docs/adr/`**, if it exists. Read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them
+upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`)
+creates them lazily when terms or decisions actually get resolved.
+
+## Layout: single-context
+
+This repo is **single-context**: one `CONTEXT.md` and one `docs/adr/` at the root.
+
+```
+/
+├── AGENTS.md
+├── CONTEXT.md                         ← created lazily by /domain-modeling
+└── docs/
+    ├── adr/                           ← created lazily by /domain-modeling
+    │   ├── 0001-....md
+    │   └── 0002-....md
+    └── agents/                        ← this directory
+```
+
+This repo is checked out as a submodule of the umbrella repository,
+[`openaustralia/openaustralia`](https://github.com/openaustralia/openaustralia), but it is a separate repository
+with its own domain docs. They belong here, in this repo — not in the umbrella checkout.
+
+If this repo ever does need per-context docs, the multi-context form is a root `CONTEXT-MAP.md` pointing at one
+`CONTEXT.md` per context, with context-scoped ADRs alongside each.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use
+the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal. Either you're inventing language the project
+doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+Use the exact service names in prose: Planning Alerts, Right to Know, They Vote for You, OpenAustralia.org.au and
+morph.io. Never invent variants.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0003 (...), but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,69 @@
+# Issue tracker: GitHub (umbrella repo)
+
+Issues and specs for this repo live as GitHub issues in the umbrella repository,
+[`openaustralia/openaustralia`](https://github.com/openaustralia/openaustralia) — GitHub Issues are **disabled**
+on `openaustralia/twfy`. Use the `gh` CLI with an explicit `-R openaustralia/openaustralia` for every issue
+operation; `gh`'s automatic repo inference from this clone would target the wrong repo.
+
+When an issue is specific to this repo, name it (`twfy`) in the title or body so it's findable among the
+umbrella repo's cross-cutting issues.
+
+## Conventions
+
+- **Create an issue**: `gh issue create -R openaustralia/openaustralia --title "..." --body "..."`. Use a heredoc
+  for multi-line bodies. Follow the org issue templates in
+  [`openaustralia/.github`](https://github.com/openaustralia/.github/tree/main/.github/ISSUE_TEMPLATE).
+- **Read an issue**: `gh issue view <number> -R openaustralia/openaustralia --comments`, filtering comments by
+  `jq` and also fetching labels.
+- **List issues**: `gh issue list -R openaustralia/openaustralia --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> -R openaustralia/openaustralia --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> -R openaustralia/openaustralia --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> -R openaustralia/openaustralia --comment "..."`
+
+Never bulk-close issues. Present a not-reproducible or stale verdict as evidence and let a human decide, except
+for outright duplicates and issues whose context no longer exists.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage`
+reads this flag.)_
+
+Pull requests live on **this** repo (`openaustralia/twfy`) — only issues are centralised. When the flag is
+set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents against this
+repo (no `-R` needed inside the clone):
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+Dependabot PRs are automated maintenance, not requests; keep them out of any triage queue.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `openaustralia/openaustralia` (with `-R openaustralia/openaustralia`).
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> -R openaustralia/openaustralia --comments`.
+
+## Opening pull requests
+
+Open PRs on this repo. Use the org pull request template from
+[`openaustralia/.github`](https://github.com/openaustralia/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md),
+and assign yourself: `gh pr create --assignee @me`. Note AI involvement and the model in the PR body.
+
+After merging a change here, the umbrella repository's submodule pointer must be bumped before production picks
+it up.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets. All wayfinding issue
+commands target the umbrella repo — pass `-R openaustralia/openaustralia` (or `repos/openaustralia/openaustralia`
+paths for `gh api`) throughout.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create -R openaustralia/openaustralia --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/openaustralia/openaustralia/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/openaustralia/openaustralia/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list -R openaustralia/openaustralia --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> -R openaustralia/openaustralia --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> -R openaustralia/openaustralia --body "<answer>"`, then `gh issue close <n> -R openaustralia/openaustralia`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,28 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings
+used in this repo's issue tracker — the umbrella repo, `openaustralia/openaustralia` (see
+`docs/agents/issue-tracker.md`). That tracker keeps the default vocabulary, so both columns match.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (for example "apply the AFK-ready triage label"), use the corresponding label string
+from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+All five labels exist on `openaustralia/openaustralia`. Two were renamed from earlier labels rather than created,
+so older issues and comments may still refer to them by the old name: `needs-info` was `needs-reproduction`, and
+`ready-for-human` was `ready`.
+
+## Other labels on the tracker
+
+The umbrella repo also carries labels outside the five canonical roles — type and area labels such as `bug`,
+`task`, `New feature`, `improvement`, `parser`, `web app`, `votes`, `API`, plus `needs-dev-env` and `stale`. The
+skills don't read them; leave them alone unless you are deliberately triaging with them.


### PR DESCRIPTION
## Description

Scaffolds the per-repo configuration that the engineering skills (Matt Pocock's skills: `to-tickets`, `triage`, `to-spec`, `wayfinder`, `domain-modeling`, etc.) read:

- `docs/agents/issue-tracker.md` — issues for this repo live in the umbrella repo, [`openaustralia/openaustralia`](https://github.com/openaustralia/openaustralia) (GitHub Issues are disabled here), so all `gh issue` commands carry `-R openaustralia/openaustralia`. PRs stay on this repo. "PRs as a request surface" is off by default.
- `docs/agents/triage-labels.md` — the default five-role triage vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), matching the labels that already exist on the umbrella tracker.
- `docs/agents/domain.md` — single-context domain doc layout: one `CONTEXT.md` and one `docs/adr/` at the root, both created lazily by `/domain-modeling`.
- `AGENTS.md` — a new `## Agent skills` section pointing at the three files above, matching the section already in the umbrella repo's `AGENTS.md`.

## Motivation and Context

The umbrella repo already has this configuration ([openaustralia/openaustralia `docs/agents/`](https://github.com/openaustralia/openaustralia/tree/main/docs/agents)); this brings the submodule repos in line so agents working in any checkout know where issues live, which triage labels to use, and where domain docs go.

## How Has This Been Tested?

- [x] Documentation-only change; verified the referenced umbrella-repo labels and issue conventions exist
- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

_AI involvement: drafted by OpenCode running `amazon-bedrock/anthropic.claude-fable-5`, reviewed by @benrfairless._
