### PR TITLE
remove trailing whitespace

### DIFF
--- a/scripts/xml2db.pl
+++ b/scripts/xml2db.pl
@@ -5,11 +5,11 @@ use strict;
 # $Id: xml2db.pl,v 1.23 2008/01/26 09:34:42 twfy-staging Exp $
 #
 # Loads XML written answer, debate and member files into the fawkes database.
-# 
+#
 # Magic numbers, and other properties of the destination schema
 # are documented here:
 #        http://parl.stand.org.uk/cgi-bin/moin.cgi/DataSchema
-#        
+#
 # The XML files for Hansard objects come from the Public Whip parser:
 #       http://scm.kforge.net/plugins/scmsvn/cgi-bin/viewcvs.cgi/trunk/parlparse/pyscraper/?root=ukparse
 # And those for MPs are in (semi-)manually updated files here:
@@ -25,7 +25,7 @@ mySociety::Config::set_file('../conf/general');
 
 my $parldata = mySociety::Config::get('RAWDATA');
 
-use DBI; 
+use DBI;
 use XML::Twig;
 use File::Find;
 use Getopt::Long;
@@ -83,7 +83,7 @@ Loads XML files from the parldata (pwdata) directory into the fawkes database.
 The input files contain debates, written answers and so on, and were generated
 by pyscraper from parlparse. This script synchronises the database to the
 files, so existing entries with the same gid are updated preserving their
-database id. 
+database id.
 
 --wrans - process Written Answers (C&L)
 --debates - process Commons Debates
@@ -103,7 +103,7 @@ database id.
 
 --force - also delete items from database that weren't in the XML
           file (applied per day only)
---quiet - don't print the contents whenever an existing entry is 
+--quiet - don't print the contents whenever an existing entry is
           modified or deleted
 --cronquiet - stop printing date names as entries are processed
 
@@ -211,7 +211,7 @@ sub process_type {
                         if (m/^$xname(\d{4}-\d\d-\d\d)([a-z]*)\.xml$/
                             || /^$xname\d{4}-\d\d-\d\d_[^_]*_[^_]*_(\d{4}-\d\d-\d\d)([a-z]*)\.xml$/) {
                                 my $date_part = $1;
-        
+
                                 if ($xmaxtime[$i] < $stat[9]) {
                                         $xmaxfile = $xfile;
                                         $xmaxtime[$i] = $stat[9];
@@ -257,10 +257,10 @@ sub process_type {
                         }
                         $xmaxtime[$i] = $stat[9];
                 }
-       
+
                 if ($xxmaxtime != $xsince) {
                         # We use the current maxtime, so we run things still at that time again
-                        # (the rsync from parlparse might have only got one of two files set in 
+                        # (the rsync from parlparse might have only got one of two files set in
                         # the same second, and next time it might get the other)
                         #print "$xname since: $xsince new max $xmaxtime from changedates\n";
                         my $xdir = $xdirs->[0];
@@ -382,7 +382,7 @@ sub fix_case_part
         # This mainly applies to departmental names for Oral Answers to Questions
 #        print "fix_case_part " . $_ . "\n";
 
-        s/\s+$//g; 
+        s/\s+$//g;
         s/^\s+//g;
         s/\s+/ /g;
 
@@ -415,10 +415,10 @@ sub parsefile_glob {
 ##########################################################################
 # Database
 
-my ($dbh, 
+my ($dbh,
         $epadd, $epcheck, $epupdate,
         $hadd, $hcheck, $hupdate, $hdelete, $hdeletegid,
-        $constituencyadd, $constituencydel, $memberadd, $memberexist, $membercheck, 
+        $constituencyadd, $constituencydel, $memberadd, $memberexist, $membercheck,
         $gradd, $grcheck, $grdeletegid,
         $lastid);
 
@@ -449,13 +449,13 @@ sub db_connect
                 (cons_id, name, main_name, from_date, to_date) values
                 (?, ?, ?, ?, ?)");
         $memberadd = $dbh->prepare("replace into member (member_id, person_id, house, title, first_name, last_name,
-                constituency, party, entered_house, left_house, entered_reason, left_reason) 
+                constituency, party, entered_house, left_house, entered_reason, left_reason)
                 values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
         $memberexist = $dbh->prepare("select member_id from member where member_id = ?");
         $membercheck = $dbh->prepare("select member_id from member where
                 member_id = ? and person_id = ? and house = ? and title = ? and first_name = ? and last_name = ?
                 and constituency = ? and party = ? and entered_house = ? and left_house = ?
-                and entered_reason = ? and left_reason = ?"); 
+                and entered_reason = ? and left_reason = ?");
 
         # gidredirect entries
         $gradd = $dbh->prepare("replace into gidredirect (gid_from, gid_to, hdate, major) values (?,?,?,?)");
@@ -487,7 +487,7 @@ sub delete_lonely_epobjects()
         my $r2 = $dbh->selectcol_arrayref("select count(*) from hansard");
         my $c2 = $r2->[0];
         return if $c2 == $c1;
-        
+
         print "Fixing up lonely epobjects. Counts: $c1 $c2\n" unless $cronquiet;
         my $q = $dbh->prepare("select epobject_id from epobject");
         $q->execute();
@@ -541,7 +541,7 @@ sub check_extra_gids
         # code is partly a double check.
         my %xml_hash;
         foreach my $gid (@xml_gids) {
-                $xml_hash{$gid} = 1; 
+                $xml_hash{$gid} = 1;
         }
         my $missing = 0;
         foreach my $gid (@mysql_allgids) {
@@ -550,7 +550,7 @@ sub check_extra_gids
                         $missing++;
                         my $vital = 0;
                         # check no comments, votes etc.
-                        for my $entry (["comments", "epobject_id",], 
+                        for my $entry (["comments", "epobject_id",],
                                            ["anonvotes", "epobject_id",],
                                            ["uservotes", "epobject_id",],
                                            ["editqueue", "epobject_id_l",],
@@ -582,14 +582,14 @@ sub check_extra_gids
                                                                 next;
                                                         }
                                                 }
-                                        }                                
+                                        }
                                         print "VITAL ERROR! gid $gid needs deleting, has an entry in table $table, but no gid redirect\n";
                                         $vital++;
                                 }
                         }
                         # either fix it, or display it
                         if ($force) {
-                                if ($vital > 0) { 
+                                if ($vital > 0) {
                                         die "Refusing to even force delete, when there are references in other tables\n";
                                 } else {
                                         $hdeletegid->execute($gid);
@@ -638,7 +638,7 @@ sub delete_redirected_gids {
                 }
 
                 # move comments and votes and so forth to redirected gid destination
-                for my $entry (["comments", "epobject_id",], 
+                for my $entry (["comments", "epobject_id",],
                                    ["anonvotes", "epobject_id",],
                                    ["uservotes", "epobject_id",],
                                    ["editqueue", "epobject_id_l",],
@@ -702,7 +702,7 @@ sub db_addpair
         my $major = $$hparams[3];
 
         $ignorehistorygids{$gid} = 1;
-       
+
         # Depending on what mode we're in
         if ($tallygidsmode) {
                 die "Got gid $gid twice in XML file" if (defined $gids{$gid});
@@ -771,7 +771,7 @@ sub db_addpair
         }
         $hcheck->finish();
         $grcheck->finish();
-        
+
         $epadd->execute(@$epparams);
         my $epid = last_id();
         $epadd->finish();
@@ -779,7 +779,7 @@ sub db_addpair
         $hadd->finish();
 
         # print "added " . $gid . "\n";
-        
+
         return $epid;
 }
 
@@ -874,17 +874,17 @@ sub memory_test
 
 sub add_mps_and_peers {
         $dbh->do("delete from moffice");
-        my $twig = XML::Twig->new(twig_handlers => 
-                { 'constituency' => \&loadconstituency, 
-                  'member' => \&loadmember, 
-                  'lord' => \&loadlord, 
-                  'royal' => \&loadroyal, 
+        my $twig = XML::Twig->new(twig_handlers =>
+                { 'constituency' => \&loadconstituency,
+                  'member' => \&loadmember,
+                  'lord' => \&loadlord,
+                  'royal' => \&loadroyal,
                   'member_ni' => \&loadni,
                   'member_sp' => \&loadmsp,
                   'person' => \&loadperson,
-                  'moffice' => \&loadmoffice }, 
+                  'moffice' => \&loadmoffice },
                 output_filter => $outputfilter );
-        $constituencydel->execute(); 
+        $constituencydel->execute();
         $constituencydel->finish();
         my $pwmembers = mySociety::Config::get('PWMEMBERS');
         $twig->parsefile($pwmembers . "divisions.xml");
@@ -898,7 +898,7 @@ sub add_mps_and_peers {
 }
 
 sub check_member_ids {
-        my $q = $dbh->prepare("select member_id from member"); 
+        my $q = $dbh->prepare("select member_id from member");
         $q->execute();
         while (my @row = $q->fetchrow_array) {
                 print "Member $row[0] in DB, not in XML\n" if (!$member_ids{$row[0]});
@@ -924,7 +924,7 @@ sub loadmoffices {
         }
         foreach my $row (@moffices) {
                 next unless $row;
-                my $sth = $dbh->do("insert into moffice (dept, position, from_date, to_date, person, source) values (?, ?, ?, ?, ?, ?)", {}, 
+                my $sth = $dbh->do("insert into moffice (dept, position, from_date, to_date, person, source) values (?, ?, ?, ?, ?, ?)", {},
                 $row->[1], $row->[2], $row->[3], $row->[4], $row->[5], $row->[6]);
         }
 }
@@ -970,7 +970,7 @@ sub loadconstituency
     for (my $name = $cons->first_child('name'); $name;
         $name = $name->next_sibling('name')) {
 
-        # We encode entities as e.g. &Ouml;, as otherwise non-ASCII characters         
+        # We encode entities as e.g. &Ouml;, as otherwise non-ASCII characters
         # get lost somewhere between Perl, the database and the browser.
         $constituencyadd->execute(
             $consid,
@@ -1005,21 +1005,21 @@ sub loadmember {
 			$house = 2;
 		}
         else {
-                die "Unknown house"; 
+                die "Unknown house";
         }
-        
+
         # We encode entities as e.g. &Ouml;, as otherwise non-ASCII characters
         # get lost somewhere between Perl, the database and the browser.
         # Just done for names (not constituency and party) as they are the
         # only place to have accents, and constituencies have & signs and
         # the postcode search matching system uses them.
-        db_memberadd($id, 
+        db_memberadd($id,
                 $person_id,
-                $house, 
+                $house,
                 encode_entities_noapos($member->att('title')),
-                encode_entities_noapos($member->att('firstname')), 
+                encode_entities_noapos($member->att('firstname')),
                 encode_entities_noapos($member->att('lastname')),
-                encode_entities_noapos($member->att('division')), 
+                encode_entities_noapos($member->att('division')),
                 $member->att('party'),
                 $member->att('fromdate'), $member->att('todate'),
                 $member->att('fromwhy'), $member->att('towhy'));
@@ -1033,13 +1033,13 @@ sub loadlord {
         my $person_id = $membertoperson{$id};
         $id =~ s:uk.org.publicwhip/lord/::;
         $person_id =~ s:uk.org.publicwhip/person/::;
-#        print "$id $person_id ".$member->att('title').' '.$member->att('lordname')."\n"; 
+#        print "$id $person_id ".$member->att('title').' '.$member->att('lordname')."\n";
 
         my $house = 2;
         if ($member->att('house') ne "lords") {
-                die "Unknown house"; 
+                die "Unknown house";
         }
-        
+
         my $fromdate = $member->att('fromdate');
         $fromdate = "$fromdate-01-01" if length($fromdate)==4;
         $fromdate = '0000-00-00' unless $fromdate;
@@ -1055,7 +1055,7 @@ sub loadlord {
                 $house,
                 encode_entities_noapos($member->att('title')),
                 $member->att('forenames'),
-                $member->att('lordname'), 
+                $member->att('lordname'),
                 encode_entities_noapos($member->att('lordofname')),
                 $affiliation,
                 $fromdate, $member->att('todate'),
@@ -1078,7 +1078,7 @@ sub loadroyal {
                 $person_id,
                 $house,
                 encode_entities_noapos($member->att('title')),
-                encode_entities_noapos($member->att('firstname')), 
+                encode_entities_noapos($member->att('firstname')),
                 encode_entities_noapos($member->att('lastname')),
                 '', # No constituency, all land is "held of the Crown"
                 '', # No party, constitutionally
@@ -1094,13 +1094,13 @@ sub loadni {
         $id =~ s:uk.org.publicwhip/member/::;
         $person_id =~ s:uk.org.publicwhip/person/::;
         my $house = 3;
-        db_memberadd($id, 
+        db_memberadd($id,
                 $person_id,
-                $house, 
+                $house,
                 encode_entities_noapos($member->att('title')),
-                encode_entities_noapos($member->att('firstname')), 
+                encode_entities_noapos($member->att('firstname')),
                 encode_entities_noapos($member->att('lastname')),
-                encode_entities_noapos($member->att('constituency')), 
+                encode_entities_noapos($member->att('constituency')),
                 Encode::encode('iso-8859-1', $member->att('party')),
                 $member->att('fromdate'), $member->att('todate'),
                 $member->att('fromwhy'), $member->att('towhy'));
@@ -1113,13 +1113,13 @@ sub loadmsp {
         $id =~ s:uk.org.publicwhip/member/::;
         $person_id =~ s:uk.org.publicwhip/person/::;
         my $house = 4;
-        db_memberadd($id, 
+        db_memberadd($id,
                 $person_id,
-                $house, 
+                $house,
                 encode_entities_noapos($member->att('title')),
-                encode_entities_noapos($member->att('firstname')), 
+                encode_entities_noapos($member->att('firstname')),
                 encode_entities_noapos($member->att('lastname')),
-                encode_entities_noapos($member->att('constituency')), 
+                encode_entities_noapos($member->att('constituency')),
                 Encode::encode('iso-8859-1', $member->att('party')),
                 $member->att('fromdate'), $member->att('todate'),
                 $member->att('fromwhy'), $member->att('towhy'));
@@ -1144,9 +1144,9 @@ sub loadperson {
 sub add_wrans_day
 {
         my ($date) = @_;
-        
+
         use vars qw($lordshead);
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                         'ques' => sub { do_load_speech($_, 3, 1, $_->sprint(1)) },
                         'reply' => sub { do_load_speech($_, 3, 2, $_->sprint(1)) },
                         'minor-heading' => sub {
@@ -1199,7 +1199,7 @@ sub add_wrans_day
 
         # and delete anything that has been redirected (moving comments etc)
         delete_redirected_gids($date, \%grdests);
-         
+
         undef $twig;
 }
 
@@ -1209,7 +1209,7 @@ sub add_wrans_day
 sub add_debates_day
 {
         my ($date) = @_;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'speech' => sub { do_load_speech($_, 1, 0, $_->sprint(1)) },
                 'minor-heading' => sub { do_load_subheading($_, 1, strip_string($_->sprint(1))) },
                 'major-heading' => sub { load_debate_heading($_, 1) },
@@ -1239,7 +1239,7 @@ sub add_debates_day
 }
 
 # load <major-heading> tags
-sub load_debate_heading { 
+sub load_debate_heading {
         my ($speech, $major) = @_;
         # we merge together the Oral Answers to Questions major heading with the
         # major headings "under" it.
@@ -1260,7 +1260,7 @@ sub load_debate_division {
         my ($division, $major) = @_;
         my $divdate = $division->att('divdate');
         my $divnumber = $division->att('divnumber');
-        my $text = 
+        my $text =
 "<p class=\"divisionheading\">Division number $divnumber</p>
 <p class=\"divisionbody\"><a href=\"" . mySociety::Config::get('PUBLICWHIP_HOST') . "/division.php?date=$divdate&amp;number=$divnumber";
         $text .= '&amp;house=lords' if $major == 101;
@@ -1276,7 +1276,7 @@ list of votes</a> (From <a href=\"" . mySociety::Config::get('PUBLICWHIP_HOST') 
 sub add_lordsdebates_day
 {
         my ($date) = @_;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'speech' => sub { do_load_speech($_, 101, 0, $_->sprint(1)) },
                 'minor-heading' => sub { do_load_subheading($_, 101, strip_string($_->sprint(1))) },
                 'major-heading' => sub { load_debate_heading($_, 101) },
@@ -1310,7 +1310,7 @@ sub add_lordsdebates_day
 sub add_westminhall_day
 {
         my ($date) = @_;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'speech' => sub { do_load_speech($_, 2, 0, $_->sprint(1)) },
                 'minor-heading' => sub { do_load_subheading($_, 2, strip_string($_->sprint(1))) },
                 'major-heading' => sub { load_debate_heading($_, 2) },
@@ -1428,7 +1428,7 @@ sub load_lords_wms_speech {
 
 sub add_ni_day {
         my ($date) = @_;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'speech' => sub {
                         my $speech = $_;
                         if (!$currsection && !$currsubsection) {
@@ -1463,7 +1463,7 @@ sub add_ni_day {
         undef $twig;
 }
 
-sub load_ni_heading { 
+sub load_ni_heading {
         my ($speech, $inoralanswers) = @_;
         my $text = strip_string($speech->sprint(1));
         if ($inoralanswers) {
@@ -1478,7 +1478,7 @@ sub load_ni_heading {
 
 sub add_scotland_day {
         my ($date) = @_;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'speech'        => sub { do_load_speech($_, 7, 0, $_->sprint(1)) },
                 'minor-heading' => sub { do_load_subheading($_, 7, strip_string($_->sprint(1))) },
                 'major-heading' => sub { do_load_heading($_, 7, strip_string($_->sprint(1))) },
@@ -1524,7 +1524,7 @@ sub load_scotland_division {
 
 sub add_scotwrans_day {
         my ($date) = @_;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'ques' => sub { do_load_speech($_, 8, 1, $_->sprint(1)) },
                 'reply' => sub { do_load_speech($_, 8, 2, $_->sprint(1)) },
                 'minor-heading' => sub { do_load_heading($_, 8, strip_string($_->sprint(1))) },
@@ -1588,7 +1588,7 @@ sub add_standing_day {
         my ($date) = @_;
         use vars qw($bill $bill_id $majorheadingstate @preheadingspeech);
         $majorheadingstate = 0;
-        my $twig = XML::Twig->new(twig_handlers => { 
+        my $twig = XML::Twig->new(twig_handlers => {
                 'bill' => sub {
                         $bill = strip_string($_->att('title'));
                         my $url = $_->att('url');
@@ -1789,7 +1789,7 @@ sub do_load_heading
 
         my $type = 10;
         my $speaker = 0;
-       
+
         my @epparam = (fix_case($text));
         my @hparam = ($speech->att('id'), $type, $speaker, $major, $minor, 0, 0, $hpos, $curdate, $htime, $url);
         my $epid = db_addpair(\@epparam, \@hparam);
@@ -1848,7 +1848,7 @@ sub do_load_gidredirect
 {
         my ($gidredirect, $major) = @_;
 
-        my $oldgid = $gidredirect->att('oldgid'); 
+        my $oldgid = $gidredirect->att('oldgid');
         my $newgid = $gidredirect->att('newgid');
         my $matchtype = $gidredirect->att('matchtype');
         # if matchtype is multiplecover, let through >1 identical GIDs
@@ -1867,7 +1867,7 @@ sub do_load_gidredirect
                 $gids{$oldgid} = 1;
                 return if ($matchtype eq 'removed');
         }
- 
+
         $gradd->execute($oldgid, $newgid, $curdate, $major);
         $gradd->finish();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes trailing whitespace from perl file

## Motivation and Context
every time i save the file in my editor, it strips there out, and i have to hunt around for which lines to actually commit to git.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- [ ] Checked affected area manually on my own / staging system
<!--- Include details of your testing environment -->
<!--- Detail the tests you ran to see how your change affects other areas of the code, etc. -->
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
