### PR TITLE
allow env var override in perl parsing scripts

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -1,0 +1,35 @@
+# Dev-only scripts for working against the sibling ../openaustralia-parser checkout.
+# Not part of the main build/test/deploy chain (see Makefile for that); include as needed:
+#   make -f Makefile.dev <target>
+
+TWFY_MYSQL_PORT ?= 3306
+
+# Must match ../openaustralia-parser/configuration.yml's xml_path (relative to that dir).
+PARSER_XML_PATH := $(CURDIR)/../openaustralia-parser/tmp/pwdata/
+
+# Same _xapiandb/ dir the docker webhost container reads (mounted to /app/shared/search).
+XAPIANDB := $(CURDIR)/_xapiandb/searchdb
+XAPIANDB_LASTUPDATED := $(CURDIR)/_xapiandb/searchdb-lastupdated
+
+.PHONY: parse-members parse-speeches xapian-index
+
+# Parse member data (from ../openaustralia-parser) and load it into the local dev DB.
+# DB_HOST/DB_PORT override conf/general's DB_HOST ("mysql", the docker-compose service
+# name) so scripts/xml2db.pl can reach the docker-compose mysql container from the host.
+# RAWDATA overrides conf/general's RAWDATA (docker path /app/shared/pwdata/) so
+# xml2db.pl reads the XML that the parser actually wrote to on the host.
+parse-members:
+	cd ../openaustralia-parser && DB_HOST=127.0.0.1 DB_PORT=$(TWFY_MYSQL_PORT) RAWDATA=$(PARSER_XML_PATH) bin/run parse-members.rb
+
+# Parse Hansard speeches (from ../openaustralia-parser) and load them into the local dev DB.
+# ARGS is passed through to parse-speeches.rb, e.g.:
+#   make -f Makefile.dev parse-speeches ARGS="2026-08-10 2026-08-12"
+parse-speeches:
+	cd ../openaustralia-parser && DB_HOST=127.0.0.1 DB_PORT=$(TWFY_MYSQL_PORT) RAWDATA=$(PARSER_XML_PATH) bin/run parse-speeches.rb $(ARGS)
+
+# (Re)index rows added/changed since the last run into _xapiandb/, so newly parsed
+# speeches become searchable. Needed after parse-members/parse-speeches for search to
+# pick up new data; the site falls back to slower MySQL search if _xapiandb/ is empty.
+xapian-index:
+	mkdir -p _xapiandb
+	cd search && DB_HOST=127.0.0.1 DB_PORT=$(TWFY_MYSQL_PORT) ./index.pl $(XAPIANDB) sincefile $(XAPIANDB_LASTUPDATED)

--- a/scripts/xml2db.pl
+++ b/scripts/xml2db.pl
@@ -23,7 +23,9 @@ use lib "$FindBin::Bin/../../perllib";
 use mySociety::Config;
 mySociety::Config::set_file('../conf/general');
 
-my $parldata = mySociety::Config::get('RAWDATA');
+# RAWDATA env var wins over conf/general's RAWDATA (the docker container path
+# /app/shared/pwdata/), so this can point at a host-side XML output dir instead.
+my $parldata = $ENV{RAWDATA} || mySociety::Config::get('RAWDATA');
 
 use DBI;
 use XML::Twig;
@@ -425,7 +427,11 @@ my ($dbh,
 sub db_connect
 {
         # Connect to database, and prepare queries
-        my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('DB_NAME'). ':host=' . mySociety::Config::get('DB_HOST');
+        # DB_HOST/DB_PORT env vars win over conf/general's DB_HOST (which is "mysql",
+        # the docker-compose service name, only resolvable from inside the docker network).
+        my $db_host = $ENV{DB_HOST} || mySociety::Config::get('DB_HOST');
+        my $db_port = $ENV{DB_PORT} || 3306;
+        my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('DB_NAME') . ':host=' . $db_host . ':port=' . $db_port;
         $dbh = DBI->connect($dsn, mySociety::Config::get('DB_USER'), mySociety::Config::get('DB_PASSWORD'), { RaiseError => 1, PrintError => 0 });
 
         # epobject queries

--- a/search/index.pl
+++ b/search/index.pl
@@ -23,17 +23,21 @@ my $dbfile=shift;
 die "Specify Xapian database file as first parameter" if !$dbfile;
 my $action=shift;
 die "As second parameter, specify:
-    'all' to (re)index everything (sometimes memory leaks and doesn't work see indexall.sh), or 
-    'lastweek' to (re)index just the last week, or 
-    'lastmonth' to (re)index just the last month, or 
+    'all' to (re)index everything (sometimes memory leaks and doesn't work see indexall.sh), or
+    'lastweek' to (re)index just the last week, or
+    'lastmonth' to (re)index just the last month, or
     'daterange' to (re)index between two dates, specified as next parameters
-    'sincefile' to (re)index updates since a given date (specified in unixtime inside a file as 
+    'sincefile' to (re)index updates since a given date (specified in unixtime inside a file as
                    the last parameter, the file is updated to now after indexing)
     'check' to check everything is indexed
 " if !$action or ($action ne "all" and $action ne "lastweek" and $action ne "lastmonth" and $action ne "sincefile" and $action ne "check" and $action ne "daterange");
 
 # Open MySQL
-my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('DB_NAME'). ':host=' . mySociety::Config::get('DB_HOST');
+# DB_HOST/DB_PORT env vars win over conf/general's DB_HOST ("mysql", the docker-compose
+# service name), so this can be run against the docker-compose mysql container from the host.
+my $db_host = $ENV{DB_HOST} || mySociety::Config::get('DB_HOST');
+my $db_port = $ENV{DB_PORT} || 3306;
+my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('DB_NAME') . ':host=' . $db_host . ':port=' . $db_port;
 $dbh = DBI->connect($dsn, mySociety::Config::get('DB_USER'), mySociety::Config::get('DB_PASSWORD'), { RaiseError => 1, PrintError => 0 });
 
 # Work out when to update from, for "sincefile" case
@@ -51,7 +55,7 @@ if ($action eq "sincefile") {
         close FH;
     } else {
         # No file, update everything
-        $since_date_condition = "";        
+        $since_date_condition = "";
     }
     # Store time we need to update from next time
     my $sth = $dbh->prepare("select unix_timestamp(now())");
@@ -91,13 +95,13 @@ if ($action ne "check") {
     # Batch numbers - each new stuff gets a new batch number
     my $max_indexbatch = $dbh->selectrow_array('select max(indexbatch_id) from indexbatch');
     my $new_indexbatch = $max_indexbatch + 1;
-    
-    # Get data for items to update from MySQL 
-    my $query = "select epobject.epobject_id, body, person_id, hdate, gid, major, 
+
+    # Get data for items to update from MySQL
+    my $query = "select epobject.epobject_id, body, person_id, hdate, gid, major,
         section_id, subsection_id, party,
         unix_timestamp(concat(hdate, ' ', if(htime, htime, 0))) as unix_time,
         unix_timestamp(hansard.created) as created, hpos
-        from epobject, hansard 
+        from epobject, hansard
 	    left join member on hansard.speaker_id = member.member_id
 	    where epobject.epobject_id = hansard.epobject_id";
     if ($action eq "lastweek") {
@@ -142,7 +146,7 @@ if ($action ne "check") {
             }
         }
         #print "$gid $person_id $$row{'major'}\n";
-        
+
         # Make new post for this item in Xapian
         $::doc=new Search::Xapian::Document();
         #print Dumper($row);
@@ -176,7 +180,7 @@ if ($action ne "check") {
         $::doc->add_value(6, sprintf('%010s', $$row{'created'}) . ':' . sprintf('%05s', $$row{'hpos'}));
         $::doc->add_value(7, $$row{'section_id'} . ':' . ($$row{'subsection_id'}==0?$$row{'epobject_id'}:$$row{'subsection_id'}));
         $::n=1;
-        $parser->parse($$row{'body'}); 
+        $parser->parse($$row{'body'});
         $parser->eof();
 
         # See if we already have the document in Xapian
@@ -230,7 +234,7 @@ if ($action ne "check") {
         }
         $allterms++;
     }
-    # Compare them. 
+    # Compare them.
     # Check for items in Xapian not in MySQL:
     foreach my $xapian_gid (keys %xapian_gids) {
         my $in_mysql = $mysql_gids{$xapian_gid};


### PR DESCRIPTION

## Description

Changes to the perl scripts to allow overriding settings with environment variables

## Motivation and Context

so i can spin up tests against docker, to test the parser is pulling there data we expect

## How Has This Been Tested?

Locally in my TWFY dev, calling the openaustralia-parser from a feature branch.

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
