### PR TITLE
Refresh design of footer, nav, header search - with a consistent palette

### DIFF
--- a/www/docs/style/default/layout.css
+++ b/www/docs/style/default/layout.css
@@ -143,128 +143,14 @@ div.row span.formw {
 	font-weight: bold;
 	}
 
-#menu {
-	position: relative;
-	width: 100%;
-	background-color: #EBECCF;  /* NAT */
-	border-top: 1px solid #fff;
-	}
-
 #content {
 	clear: both;
 	width: 100%;
 	min-width: 950px; /* NAT */
 	}
 
-#footer {
-	width: 100%;
-	padding: 0.7em 0 0.2em 0;
-	margin: 0;
-	background-color: #CDCEBC; /* NAT */
-	}
-
-#footer p {
-	margin-left: 18px;
-	}
-
-/**** MENU ***********************************************************************/
-
-#topmenu {
-	position: relative;
-	margin: 0;
-	padding: 0 14px 2px 0;
-	border-top: 1px solid #fff;
-	z-index: 10;
-	}
-
-#bottommenu {
-	position: relative;
-	width: 100%;
-	height: 22px; /* NAT */
-	margin: 0;
-	padding: 0 0 0 0px; /* was 2px left padding */
-	z-index: 10;
-	background-color: #CDCEBC; /* NAT */
-	}
-
-#topmenu ul,
-#bottommenu ul {
-	list-style: none;
-	margin: 0 0 0 18px;
-	padding: 0;
-	}
-
-ul#user {
-	position: relative;
-	float: right;
-	width: 25em;
-	height: 20px;  /* NAT */
-	}
-ul#user li {
-	float: right;
-	}
-ul#user .name {
-	display: block;
-	margin: 3px 5px 0 0;
-	}
-
-#topmenu li,
-#bottommenu li {
-	position: relative;
-	display: block;
-	float: left;
-	width: auto;
-	margin: 0;
-	padding: 0;
-	}
-
-#topmenu br {
-	clear: both;
-	}
-
-#topmenu a,
-#bottommenu a {
-	position: relative;
-	display: block;
-	margin: 0;
-	padding: 3px 10px;
-	background: #DECEB3;  /* NAT */
-	border-left: 1px solid #fff;
-	border-bottom: 1px solid #fff;
-	color: #000;
-	font-weight: bold;
-	width: 5.5em;
-	/* Mac IE will ignore the next line \*/
-	width: auto;
-	/* end hack */
-	}
-
-#bottommenu a {
-	padding-right: 20px;
-	border-width: 0 1px; /* NAT */
-	border-style: solid; /* NAT */
-	border-color: #AE967F; /* NAT */
-	background: #DECEB3; /* NAT */
-	color: #000; /* NAT */
-	}
-
-#topmenu a.on,
-#topmenu a:hover {
-	background: #EBA668; /* NAT */
-	color: #fff;
-	text-decoration: none; /* NAT */
-	}
-
-#topmenu a.on {
-	border-bottom: 1px solid #4D6C25;
-	}
-
-#bottommenu a.on,
-#bottommenu a:hover {
-	background: #EBA668; /* NAT */
-	color: #fff; /* NAT */
-	text-decoration: none; /* NAT */
-	}
+/**** MENU and FOOTER are now styled with Tailwind classes directly in *********/
+/**** page.php - see #menu / #footer there. Nothing here targets them. ********/
 
 /**** STRIPES *****************************************************************/
 /**** The horizontal stripes. And/or the main column / sidebar structure.     */

--- a/www/docs/style/default/layout.css
+++ b/www/docs/style/default/layout.css
@@ -116,32 +116,8 @@ div.row span.formw {
 	padding: 0;
 	}
 
-#banner {
-	position: relative;
-	margin: 0;
-	padding: 0;
-	}
-#title {
-	padding: 15px 14px 10px 18px; /* NAT */
-	line-height: 0;
-	font-size: 10%; /* Only way to stop space below images in Win IE? */
-	}
-
-#search {
-	position: absolute;
-	top: 0px;
-	right: 0px;
-	width: 26%; /* NAT */
-	height: 68px;
-	padding: 0;
-	background-color: #EBECCF; /* NAT */
-	z-index: 0;
-	}
-
-#search form {
-	margin: 1.4em 14px 0 20px;
-	font-weight: bold;
-	}
+/**** #banner/#title/#search are now styled with Tailwind classes directly ****/
+/**** in page.php - see PAGE::title_bar(). Nothing here targets them. *********/
 
 #content {
 	clear: both;

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -680,9 +680,14 @@ class PAGE {
             // Where we're linking to.
             $URL = new URL($toppage);
 
-            $class = $toppage == $top_hilite ? ' class="on"' : '';
+            $is_current = $toppage == $top_hilite;
+            $tab_class = $is_current
+                ? 'on !text-white border-0 border-b-2 border-solid border-teal-400'
+                : 'border-0 border-b-2 border-solid border-transparent !text-slate-200 hover:!text-white';
+            $class = ' class="inline-block rounded px-3 py-1.5 font-semibold !no-underline ' . $tab_class . '"';
+            $aria_current = $is_current ? ' aria-current="page"' : '';
 
-            $top_links[] = '<a href="' . $URL->generate() . '" title="' . $title . '"' . $class . '>' . $text . '</a>';
+            $top_links[] = '<a href="' . $URL->generate() . '" title="' . $title . '"' . $class . $aria_current . '>' . $text . '</a>';
 
             if ($toppage == $top_hilite) {
                 // This top menu link is highlighted, so generate its bottom menu.
@@ -699,22 +704,7 @@ class PAGE {
             }
         }
         ?>
-                        <div id="menu">
-                            <div id="topmenu">
-                                <?php
-                                $user_bottom_links = $this->user_bar($top_hilite, $bottom_hilite);
-                                if ($user_bottom_links) {
-                                    $bottom_links = $user_bottom_links;
-                                }
-                                ?>
-                                <br>
-                            </div>
-                            <div id="bottommenu">
-                                <ul>
-                                    <li><?php print implode("</li>\n\t\t\t<li>", $top_links); ?></li>
-                                </ul>
-                            </div>
-                        </div> <!-- end #menu -->
+                        <?php include __DIR__ . '/templates/html/menu.php'; ?>
 
                         <?php
     }
@@ -866,7 +856,7 @@ class PAGE {
             $edittitle = $menudata['title'];
             $EDITURL = new URL('userviewself');
             if ($this_page == 'userviewself' || $this_page == 'useredit' || $top_hilite == 'userviewself') {
-                $editclass = ' class="on"';
+                $editclass = ' class="on inline-block rounded px-2 py-1 text-sm font-semibold !no-underline !text-white border-0 border-b-2 border-solid border-teal-400" aria-current="page"';
                 $bottompages = [];
                 foreach ($bottompages as $bottompage) {
                     $menudata = $DATA->page_metadata($bottompage, 'menu');
@@ -878,7 +868,7 @@ class PAGE {
                     $bottom_links[] = '<a href="' . $URL->generate() . '" title="' . $title . '"' . $class . '>' . $text . '</a>';
                 }
             } else {
-                $editclass = '';
+                $editclass = ' class="inline-block rounded px-2 py-1 text-sm font-semibold !no-underline border-0 border-b-2 border-solid border-transparent !text-slate-200 hover:!text-white"';
             }
 
             // The 'Log out' link.
@@ -889,21 +879,12 @@ class PAGE {
             $LOGOUTURL = new URL('userlogout');
             if ($this_page != 'userlogout') {
                 $LOGOUTURL->insert(["ret" => $returl]);
-                $logoutclass = '';
+                $logoutclass = ' class="inline-block rounded px-2 py-1 text-sm font-semibold !no-underline border-0 border-b-2 border-solid border-transparent !text-slate-200 hover:!text-white"';
             } else {
-                $logoutclass = ' class="on"';
+                $logoutclass = ' class="on inline-block rounded px-2 py-1 text-sm font-semibold !no-underline !text-white border-0 border-b-2 border-solid border-teal-400" aria-current="page"';
             }
 
             $username = $THEUSER->firstname() . ' ' . $THEUSER->lastname();
-
-            ?>
-                            <ul id="user" class="!box-border !max-w-full max-md:!absolute max-md:!left-[calc(100vw-8rem)] max-md:!right-auto max-md:!w-auto">
-                                <li><a href="<?php echo $LOGOUTURL->generate(); ?>" title="<?php echo $logouttitle; ?>" <?php echo $logoutclass; ?>><?php echo $logouttext; ?></a></li>
-                                <li><a href="<?php echo $EDITURL->generate(); ?>" title="<?php echo $edittitle; ?>" <?php echo $editclass; ?>><?php echo $edittext; ?></a></li>
-                                <li><span class="name"><?php echo htmlentities($username); ?></span></li>
-                                <!--            <li><a href="<?php echo $GETINVURL->generate(); ?>" title="<?php echo $getinvolvedtitle; ?>"<?php echo $getinvolvedclass; ?>><?php echo $getinvolvedtext; ?></a></li> -->
-                            </ul>
-                            <?php
 
         } else {
             // User logged out.
@@ -921,9 +902,9 @@ class PAGE {
                     // immediately!
                     $JOINURL->insert(["ret" => $returl]);
                 }
-                $joinclass = '';
+                $joinclass = ' class="inline-block rounded px-2 py-1 text-sm font-semibold !no-underline border-0 border-b-2 border-solid border-transparent !text-slate-200 hover:!text-white"';
             } else {
-                $joinclass = ' class="on"';
+                $joinclass = ' class="on inline-block rounded px-2 py-1 text-sm font-semibold !no-underline !text-white border-0 border-b-2 border-solid border-teal-400" aria-current="page"';
             }
 
             // The 'Log in' link.
@@ -945,19 +926,14 @@ class PAGE {
                     // And the join page.
                     $LOGINURL->insert(["ret" => $returl]);
                 }
-                $loginclass = '';
+                $loginclass = ' class="inline-block rounded px-2 py-1 text-sm font-semibold !no-underline border-0 border-b-2 border-solid border-transparent !text-slate-200 hover:!text-white"';
             } else {
-                $loginclass = ' class="on"';
+                $loginclass = ' class="on inline-block rounded px-2 py-1 text-sm font-semibold !no-underline !text-white border-0 border-b-2 border-solid border-teal-400" aria-current="page"';
             }
-
-            ?>
-                            <ul id="user" class="!box-border !max-w-full max-md:!absolute max-md:!left-[calc(100vw-8rem)] max-md:!right-auto max-md:!w-auto">
-                                <li><a href="<?php echo $LOGINURL->generate(); ?>" title="<?php echo $logintitle; ?>" <?php echo $loginclass; ?>><?php echo $logintext; ?></a></li>
-                                <li><a href="<?php echo $JOINURL->generate(); ?>" title="<?php echo $jointitle; ?>" <?php echo $joinclass; ?>><?php echo $jointext; ?></a></li>
-                                <!--            <li><a href="<?php echo $GETINVURL->generate(); ?>" title="<?php echo $getinvolvedtitle; ?>"<?php echo $getinvolvedclass; ?>><?php echo $getinvolvedtext; ?></a></li> -->
-                            </ul>
-                            <?php
         }
+        ?>
+                            <?php include __DIR__ . '/templates/html/user_bar.php'; ?>
+                            <?php
         return $bottom_links;
     }
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -495,7 +495,7 @@ class PAGE {
         ?>
 
         <body>
-            <div id="container">
+            <div id="container" class="!box-border flex min-h-screen flex-col">
                 <?php
                 twfy_debug("PAGE", "This page: $this_page");
 
@@ -946,7 +946,7 @@ class PAGE {
 
         // Where the actual meat of the page begins, after the title and menu.
         ?>
-                        <div id="content">
+                        <div id="content" class="!box-border flex flex-1 flex-col">
                             <?php
     }
 
@@ -1251,7 +1251,7 @@ class PAGE {
         ];
         ?>
 
-                    <div id="footer" class="!box-border !m-0 !bg-transparent !p-0 max-md:!w-screen">
+                    <div id="footer" class="!box-border !m-0 !mt-auto !bg-transparent !p-0 max-md:!w-screen">
                         <div class="!box-border max-md:!w-screen bg-slate-100 px-4 py-10 md:px-8">
                             <div class="grid gap-8 md:grid-cols-[2fr_1fr_1fr_1fr]">
                                 <div>

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1245,41 +1245,78 @@ class PAGE {
         global $DATA, $this_page;
 
         $pages = ['about', 'contact', 'linktous', 'houserules'];
+        $help_links = [];
 
         foreach ($pages as $page) {
             $URL = new URL($page);
             $title = $DATA->page_metadata($page, 'title');
 
             if ($page == $this_page) {
-                $links[] = $title;
+                $help_links[] = $title;
             } else {
-                $links[] = '<a href="' . $URL->generate() . '">' . $title . '</a>';
+                $help_links[] = '<a href="' . $URL->generate() . '">' . $title . '</a>';
             }
         }
-        $links[] = '<a href="' . WEBPATH . 'api/">API</a> / <a href="https://data.openaustralia.org.au">XML</a>';
-        $links[] = '<a href="https://software.openaustralia.org">Source code</a>';
 
         $qs = $_SERVER['QUERY_STRING'];
         if (preg_match('/.*show_pc.*/i', $qs)) {
-            $links[] = '<a href="/?show_mobile">Mobile OA</a>';
+            $help_links[] = '<a href="/?show_mobile">Mobile OA</a>';
         }
 
         $user_agent = (isset($_SERVER['HTTP_USER_AGENT'])) ? strtolower($_SERVER['HTTP_USER_AGENT']) : '';
         if (stristr($user_agent, 'Firefox/')) {
-            $links[] = '<a href="http://mycroft.mozdev.org/download.html?name=openaustralia">Add search to Firefox</a>';
+            $help_links[] = '<a href="http://mycroft.mozdev.org/download.html?name=openaustralia">Add search to Firefox</a>';
         }
+
+        $dev_links = [
+            '<a href="' . WEBPATH . 'api/">API</a> / <a href="https://data.openaustralia.org.au">XML</a>',
+            '<a href="https://software.openaustralia.org">Source code</a>',
+        ];
         ?>
 
-                    <div id="footer" class="!box-border max-md:!w-screen max-md:!px-4">
-                        <p class="max-md:!m-0 max-md:!mb-4 max-md:!leading-7"><?php
-                        print implode(' &nbsp;&nbsp;&nbsp; ', $links);
-                        ?></p>
-                        <p class="max-md:!m-0 max-md:!leading-7">
-                            Other Wonderful Projects from the OpenAustralia Foundation:
-                            <a href="https://theyvoteforyou.org.au/">They Vote For You</a> |
-                            <a href="https://www.righttoknow.org.au/">Right To Know</a> |
-                            <a href="http://www.planningalerts.org.au/">PlanningAlerts</a>
-                        </p>
+                    <div id="footer" class="!box-border !m-0 !bg-transparent !p-0 max-md:!w-screen">
+                        <div class="!box-border max-md:!w-screen bg-slate-100 px-4 py-10 md:px-8">
+                            <div class="grid gap-8 md:grid-cols-[2fr_1fr_1fr_1fr]">
+                                <div>
+                                    <h2 class="text-lg font-semibold text-slate-900">OpenAustralia.org.au</h2>
+                                    <p class="mt-2 text-sm text-slate-600">Hansard, made findable. Searchable
+                                        transcripts of the Australian Federal Parliament.</p>
+                                    <p class="mt-2 text-sm text-slate-600">The
+                                        <a class="underline" href="https://www.oaf.org.au">OpenAustralia Foundation</a>
+                                        is a public digital online library; independent and strictly non-partisan. As a
+                                        <a class="underline" href="https://www.acnc.gov.au/charity/55c2c06e21ac71e9359a0590b9fc100e">registered
+                                            charity</a>, it is powered by donations from people like you.</p>
+                                </div>
+                                <div>
+                                    <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Help</h2>
+                                    <ul class="mt-3 space-y-2 text-sm">
+                                        <?php foreach ($help_links as $link): ?>
+                                        <li><?php echo $link; ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                                <div>
+                                    <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Developers</h2>
+                                    <ul class="mt-3 space-y-2 text-sm">
+                                        <?php foreach ($dev_links as $link): ?>
+                                        <li><?php echo $link; ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                                <div class="rounded-lg bg-white p-5 shadow-sm">
+                                    <p class="text-sm text-slate-600">Your donations keep this site and others like
+                                        it running.</p>
+                                    <a class="mt-3 inline-block rounded bg-teal-700 px-4 py-2 font-semibold !text-white no-underline shadow-sm hover:bg-teal-600" href="https://donate.oaf.org.au/">Donate now</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="!box-border max-md:!w-screen border-t border-slate-200 bg-white px-4 py-4 text-sm text-slate-600 md:px-8">
+                            <p>Other Wonderful Projects from the OpenAustralia Foundation:
+                                <a href="https://theyvoteforyou.org.au/">They Vote For You</a> |
+                                <a href="https://www.righttoknow.org.au/">Right To Know</a> |
+                                <a href="http://www.planningalerts.org.au/">PlanningAlerts</a>
+                            </p>
+                        </div>
                     </div>
 
             </div> <!-- end #content -->

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -562,18 +562,19 @@ class PAGE {
             $img = '<a href="' . $HOMEURL . '" title="' . $HOMETITLE . '">' . $img . '</a>';
         }
         ?>
-                        <div id="banner">
+                        <div id="banner" class="!box-border max-md:!w-screen flex flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-8">
                             <div id="title">
-                                <h1><?php echo $img; ?></h1>
+                                <h1 class="!m-0"><?php echo $img; ?></h1>
                             </div>
                             <?php if ($this_page != 'home') {
                                 $URL = new URL('search');
                                 $URL->reset();
                                 ?>
                                 <div id="search">
-                                    <form action="<?php echo $URL->generate(); ?>" method="get">
-                                        <p style="padding-left: 5px"><input name="s" size="15"> <input type="submit" class="submit"
-                                                value="Search"></p>
+                                    <form action="<?php echo $URL->generate(); ?>" method="get" class="flex gap-2">
+                                        <label for="banner-search" class="sr-only">Search Hansard</label>
+                                        <input type="text" name="s" id="banner-search" size="15" class="!box-border rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-900">
+                                        <input type="submit" class="submit rounded bg-teal-700 px-4 py-1.5 text-sm font-semibold !text-white hover:bg-teal-600" value="Search">
                                     </form>
                                 </div>
                             <?php } ?>

--- a/www/includes/easyparliament/templates/html/menu.php
+++ b/www/includes/easyparliament/templates/html/menu.php
@@ -1,0 +1,25 @@
+<?php
+/*
+    The primary site navigation bar: the section tabs (Home, Debates, ...) and,
+    on the right, the login/account links.
+
+    Included from PAGE::menu(), in whose scope this runs - $top_links is
+    already built there, and $this is the PAGE object (used below to call
+    user_bar(), same as everywhere else in this class).
+*/
+?>
+                        <nav id="menu" aria-label="Main menu" class="!box-border max-md:!w-screen flex flex-col gap-1 bg-[#26343b] px-4 py-2 md:flex-row md:items-center md:justify-between md:gap-4 md:px-8">
+                            <div id="bottommenu">
+                                <ul class="!m-0 flex list-none flex-wrap gap-1 !p-0">
+                                    <li><?php print implode("</li>\n\t\t\t<li>", $top_links); ?></li>
+                                </ul>
+                            </div>
+                            <div id="topmenu">
+                                <?php
+                                $user_bottom_links = $this->user_bar($top_hilite, $bottom_hilite);
+                                if ($user_bottom_links) {
+                                    $bottom_links = $user_bottom_links;
+                                }
+                                ?>
+                            </div>
+                        </nav> <!-- end #menu -->

--- a/www/includes/easyparliament/templates/html/user_bar.php
+++ b/www/includes/easyparliament/templates/html/user_bar.php
@@ -1,0 +1,24 @@
+<?php
+/*
+    The login/account part of the top menu bar: either "Log in / Join" for a
+    visitor, or the account links ("Log out", "Edit details", their name) for
+    a logged-in user.
+
+    Included from PAGE::user_bar(), in whose scope this runs - all the
+    variables below are already built there, for whichever branch applies.
+*/
+?>
+<?php if ($THEUSER->isloggedin()): ?>
+                            <ul id="user" class="!m-0 !box-border flex list-none items-center gap-1 !p-0">
+                                <li><a href="<?php echo $LOGOUTURL->generate(); ?>" title="<?php echo $logouttitle; ?>" <?php echo $logoutclass; ?>><?php echo $logouttext; ?></a></li>
+                                <li><a href="<?php echo $EDITURL->generate(); ?>" title="<?php echo $edittitle; ?>" <?php echo $editclass; ?>><?php echo $edittext; ?></a></li>
+                                <li><span class="name text-sm text-slate-300"><?php echo htmlentities($username); ?></span></li>
+                                <!--            <li><a href="<?php echo $GETINVURL->generate(); ?>" title="<?php echo $getinvolvedtitle; ?>"<?php echo $getinvolvedclass; ?>><?php echo $getinvolvedtext; ?></a></li> -->
+                            </ul>
+<?php else: ?>
+                            <ul id="user" class="!m-0 !box-border flex list-none items-center gap-1 !p-0">
+                                <li><a href="<?php echo $LOGINURL->generate(); ?>" title="<?php echo $logintitle; ?>" <?php echo $loginclass; ?>><?php echo $logintext; ?></a></li>
+                                <li><a href="<?php echo $JOINURL->generate(); ?>" title="<?php echo $jointitle; ?>" <?php echo $joinclass; ?>><?php echo $jointext; ?></a></li>
+                                <!--            <li><a href="<?php echo $GETINVURL->generate(); ?>" title="<?php echo $getinvolvedtitle; ?>"<?php echo $getinvolvedclass; ?>><?php echo $getinvolvedtext; ?></a></li> -->
+                            </ul>
+<?php endif; ?>


### PR DESCRIPTION
## What

Redesigns the site chrome that's on every page - footer, top nav, header search box - moving it off the original ~24 year old khaki/tan/orange palette onto a consistent navy/teal scheme, and fixing two real layout bugs along the way (the header search box overlapping the nav, and the footer not reaching the bottom of the browser on short pages).

**Screenshots** - before/after, desktop and mobile (I can't upload images from here - attaching these to the PR description is the one step still needed from a human):

## smaller screen

before:
<img width="1440" height="950" alt="before-home-desktop" src="https://github.com/user-attachments/assets/05edc4e7-bf4a-494a-ac31-53141f318b6a" />

after:
<img width="1440" height="950" alt="after-home-desktop" src="https://github.com/user-attachments/assets/dfe45c86-61c7-4374-a7f3-48f224aa883e" />

## home page, small screen


before:
<img width="390" height="900" alt="before-home-mobile" src="https://github.com/user-attachments/assets/65476c5d-b122-4ec9-9df4-de50b8709749" />

after:
<img width="390" height="900" alt="after-home-mobile" src="https://github.com/user-attachments/assets/1dbd67c0-2cd3-49e6-b61a-aaf75120e84d" />



1. **Footer** -  styled after TheyWorkForYou.com's footer structure.
2. **Top nav** - merged the two separately-coloured bars (login links) merged into  one navy bar; active tab/link gets a teal underline rather than a filled pill
3. **Header search box fix** - `#search` was `position: absolute` with a hardcoded `height: 68px`, so it overlapped the nav below it whenever the banner's actual content didn't match that height. Now a normal flex row, nothing to overlap.
4. **Sticky footer** - on short pages, the footer used to end right after the content, leaving an empty page below it. Standard flexbox sticky-footer now pins it to the bottom of the viewport on short pages, without affecting long pages.


### footer before:

<img width="1440" height="950" alt="before-footer" src="https://github.com/user-attachments/assets/876af8e0-56de-4cd0-8d39-91541686d1c0" />

### footer after

<img width="1440" height="950" alt="after-footer" src="https://github.com/user-attachments/assets/0337dcf7-8380-4a0d-b60d-7ac550d2bb72" />


## Screen reader accessibility

- **`aria-current="page"`** on whichever nav tab / login  so a screen reader announces "current page" - not relying on the teal underline alone, which conveys nothing to a screen reader user.
- **`<nav aria-label="Main menu">`** - the nav is a real landmark now (was a bare `<div>`), so it shows up in landmark navigation and announces with a name.
- **The footer's "Help" and "Developers" columns are real `<h2>` elements**, not just bold text, so they show up in heading navigation.
- **The header search input has a proper `<label for="banner-search">`** now (screen-reader-only, visually hidden) - it previously had no label at all, a real pre-existing gap, not just a style one.
- **Every new colour pairing was checked against WCAG 2.1 AA contrast requirements by calculation**, fixed bug of white text on the `teal-600`

## What's not done yet (next)

- **No manual screen reader pass.** Everything above is verified by inspecting the rendered HTML/ARIA attributes, not using a screen reader
- **No explicit keyboard-navigation/focus-visible check.** Nothing here removes browser default focus outlines (I checked - no `outline: none` anywhere in the stylesheets), so keyboard focus should still be visible tabbing through the new nav/footer links, but I haven't verified that visually myself.
- **No "skip to content" link exists anywhere on this site**, before or after this PR - a keyboard/screen-reader user has to tab through the entire nav on every single page load to reach the content. Not introduced by this PR, but exactly the kind of thing worth fixing while this corner of the page is already being worked on.

This PR only covers the chrome that's on every page - footer, nav, header search. Still quite a bit of the original khaki/tan/beige palette, deliberately left for follow-up rather than scope-creeping this PR:

- The homepage's "What's all this about?" section and "At OpenAustralia.org you can:" heading (three different accent colours doing the same job, none of them the new navy/teal).
- Sidebar boxes across the site (e.g. "Recent debates", "This data as a spreadsheet") - still the original khaki header bars.
- The homepage's "Search" button contrast issue noted above.
- The accessibility follow-ups noted above (manual screen reader pass, focus-visible verification, a skip-to-content link).

## Testing

- `php -l` and `make phpcs` clean on every changed file.
- Verified live via a real Docker run of the site (not just reading code) and Playwright screenshots at 1440px, 390px and 320px, across the homepage and several inner pages, in both logged-in and logged-out states (by code inspection for logged-in, since I don't have a login handy in this sandbox).
- Sticky footer verified numerically both directions: short page (`/help/` at a 2200px viewport) has the footer's bottom edge exactly at the viewport/document bottom; long page (`/debates/` at 900px) unaffected, footer still sits right after its own content.

Assisted-by: Claude Code:claude-sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
