### PR TITLE
xml2db.pl: allow PWMEMBERS env var override, matching RAWDATA

### DIFF
--- a/Makefile.dev
+++ b/Makefile.dev
@@ -7,6 +7,9 @@ TWFY_MYSQL_PORT ?= 3306
 # Must match ../openaustralia-parser/configuration.yml's xml_path (relative to that dir).
 PARSER_XML_PATH := $(CURDIR)/../openaustralia-parser/tmp/pwdata/
 
+# Must match ../openaustralia-parser/configuration.yml's members_xml_path (relative to that dir).
+PARSER_MEMBERS_XML_PATH := $(CURDIR)/../openaustralia-parser/tmp/members_xml_output/
+
 # Same _xapiandb/ dir the docker webhost container reads (mounted to /app/shared/search).
 XAPIANDB := $(CURDIR)/_xapiandb/searchdb
 XAPIANDB_LASTUPDATED := $(CURDIR)/_xapiandb/searchdb-lastupdated
@@ -16,10 +19,12 @@ XAPIANDB_LASTUPDATED := $(CURDIR)/_xapiandb/searchdb-lastupdated
 # Parse member data (from ../openaustralia-parser) and load it into the local dev DB.
 # DB_HOST/DB_PORT override conf/general's DB_HOST ("mysql", the docker-compose service
 # name) so scripts/xml2db.pl can reach the docker-compose mysql container from the host.
-# RAWDATA overrides conf/general's RAWDATA (docker path /app/shared/pwdata/) so
-# xml2db.pl reads the XML that the parser actually wrote to on the host.
+# PWMEMBERS overrides conf/general's PWMEMBERS (docker path /app/shared/pwdata/members/)
+# so xml2db.pl reads the member XML the parser actually wrote to on the host - without
+# this it looks for /app/shared/pwdata/members/divisions.xml on the host filesystem,
+# which doesn't exist there, and fails partway through with no data loaded.
 parse-members:
-	cd ../openaustralia-parser && DB_HOST=127.0.0.1 DB_PORT=$(TWFY_MYSQL_PORT) RAWDATA=$(PARSER_XML_PATH) bin/run parse-members.rb
+	cd ../openaustralia-parser && DB_HOST=127.0.0.1 DB_PORT=$(TWFY_MYSQL_PORT) RAWDATA=$(PARSER_XML_PATH) PWMEMBERS=$(PARSER_MEMBERS_XML_PATH) bin/run parse-members.rb
 
 # Parse Hansard speeches (from ../openaustralia-parser) and load them into the local dev DB.
 # ARGS is passed through to parse-speeches.rb, e.g.:

--- a/scripts/xml2db.pl
+++ b/scripts/xml2db.pl
@@ -892,7 +892,11 @@ sub add_mps_and_peers {
                 output_filter => $outputfilter );
         $constituencydel->execute();
         $constituencydel->finish();
-        my $pwmembers = mySociety::Config::get('PWMEMBERS');
+        # PWMEMBERS env var wins over conf/general's PWMEMBERS (the docker container
+        # path /app/shared/pwdata/members/), so this can point at a host-side XML
+        # output dir instead - same reasoning as $parldata/RAWDATA above, which this
+        # member-loading path had never picked up.
+        my $pwmembers = $ENV{PWMEMBERS} || mySociety::Config::get('PWMEMBERS');
         $twig->parsefile($pwmembers . "divisions.xml");
         $twig->parsefile($pwmembers . "people.xml");
         $twig->parsefile($pwmembers . "representatives.xml");


### PR DESCRIPTION
## What

`xml2db.pl`'s member-loading path used `mySociety::Config::get('PWMEMBERS')` directly, unlike the debates-loading path right above it, which already has an `$ENV{RAWDATA}` override (`c6d7dcc6`) for the exact same reason: `conf/general`'s value points at the docker container path (`/app/shared/pwdata/...`), which doesn't exist when scripts are run on the host against the docker-compose MySQL, per `Makefile.dev`'s dev workflow.

## Why it matters

Without this, `make -f Makefile.dev parse-members` generates the member XML correctly on the host, but the load step dies partway through (`divisions.xml` missing) - and since `parse-members.rb` (in `openaustralia-parser`) never checks the Perl subprocess's exit code, this fails **silently**: exit 0, no error surfaced unless you read the log, and nothing loaded.

Found this backfilling real 2026 Hansard data into a local dev DB while testing [openaustralia-parser#253](https://github.com/openaustralia/openaustralia-parser/pull/253): the dev DB's `member` table was stuck at 212 rows with a newest `entered_house` of 2022-07-26, so recent senators (eg Steph Hodgins-May) weren't in the database at all, and their speeches couldn't resolve to a speaker on the site.

## Changes

- `scripts/xml2db.pl`: `PWMEMBERS` env var wins over `conf/general`'s value, same pattern as the existing `RAWDATA` override just above it.
- `Makefile.dev`: `parse-members` now passes `PWMEMBERS` the same way `parse-speeches` already passes `RAWDATA`.

## Testing

Verified against a real local backfill: before the fix, `make -f Makefile.dev parse-members` silently loaded nothing (212 members, unchanged). After the fix, it loads all 1300 current + historical members correctly, and the newly-loaded senators' speeches resolve to real speaker names on the site.

`perl -c scripts/xml2db.pl` clean.

Assisted-by: Claude Code:claude-sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
