### PR TITLE
Serve mobile visitors the same responsive front/transcript pages as desktop

### DIFF
--- a/conf/httpd-docker.conf
+++ b/conf/httpd-docker.conf
@@ -57,9 +57,8 @@ RewriteRule ^/senator/(.*)   /mp/$1?peer=1 [QSA]
     RewriteRule ^/news/archives/(.*)$  /news/index.php/archives/$1 [QSA]
     RewriteRule ^/news/index.rdf$      /news/rdf.php [QSA]
 
-#     # default top level / URL Mobile redirection (by exclusion)
-#     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
-#     RewriteRule         ^/$                     /mobile.php [PT]
+#     # '/' has no mobile redirect any more - index.php is a responsive/adaptive
+#     # design now (openaustralia/twfy#228), same page for mobile and desktop.
 
 #     # help/ URL Mobile redirection (by exclusion)
 #     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
@@ -69,12 +68,15 @@ RewriteRule ^/senator/(.*)   /mp/$1?peer=1 [QSA]
 #     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
 #     RewriteRule         ^/search/(.*)$            /search/mobile.php$1 [PT]
 
-#     # senate/ URL Mobile redirection (by exclusion)
+#     # senate/ URL Mobile redirection (by exclusion) - !(^|&)id= excludes the
+#     # single-debate transcript view, responsive/adaptive as of openaustralia/twfy#227
 #     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
+#     RewriteCond         %{QUERY_STRING}         !(^|&)id= [NC]
 #     RewriteRule         ^/senate/(.*)$            /senate/mobile.php$1 [QSA]
 
-#     # debates/ URL Mobile redirection (by exclusion)
+#     # debates/ URL Mobile redirection (by exclusion) - same !(^|&)id= exclusion
 #     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
+#     RewriteCond         %{QUERY_STRING}         !(^|&)id= [NC]
 #     RewriteRule         ^/debates/(.*)$            /debates/mobile.php$1 [QSA]
 
 </VirtualHost>

--- a/conf/httpd.conf.ubuntu
+++ b/conf/httpd.conf.ubuntu
@@ -78,21 +78,11 @@ RewriteRule ^/mp/(['a-zA-Z_\ +-]+)/?$       /mp/index.php?n=$1 [QSA]
 RewriteRule ^/news/archives/(.*)$  /news/index.php/archives/$1 [QSA]
 RewriteRule ^/news/index.rdf$      /news/rdf.php [QSA]
 
-    # default top level / URL Mobile redirection (by exclusion)
-    RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
-        # NOTE: May want to add other bot patters here
-        RewriteCond         %{HTTP_USER_AGENT}      !^.*(spider|crawl|slurp|bot).*$ [NC]
-    RewriteCond         %{HTTP_USER_AGENT}      ^.*webOS.*$ [NC,OR]
-    RewriteCond         %{HTTP_USER_AGENT}      !^.*Linux.*$ [NC,OR]
-    RewriteCond         %{HTTP_USER_AGENT}      ^.*Android.*$ [NC]
-    RewriteCond         %{HTTP_USER_AGENT}      !^.*Win.*$ [NC,OR]
-    RewriteCond         %{HTTP_USER_AGENT}      ^.*Windows\s+CE.*$ [NC]
-    RewriteCond         %{HTTP_USER_AGENT}      !^.*OS\s+(X|9).*$ [NC,OR]
-    RewriteCond         %{HTTP_USER_AGENT}      ^.*iPhone.*$ [NC,OR]
-    RewriteCond         %{HTTP_USER_AGENT}      ^.*iPod.*$ [NC]
-    RewriteCond         %{HTTP_USER_AGENT}      !^.*Solaris.*$ [NC]
-    RewriteCond         %{HTTP_USER_AGENT}      !^.*BSD.*$
-    RewriteRule         ^/$                     /mobile.php [PT]
+    # The front page (index.php) is a responsive/adaptive design as of the front-page
+    # redesign - mobile visitors get the same page as desktop now, not mobile.php (see
+    # openaustralia/twfy#228 and the debate transcript page redesign it stacks on,
+    # openaustralia/twfy#227). No more mobile redirect for '/' - mobile.php itself is
+    # left in place for anyone linking to it directly, just no longer routed to here.
 
     # help/ URL Mobile redirection (by exclusion)
     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
@@ -126,8 +116,13 @@ RewriteRule ^/news/index.rdf$      /news/rdf.php [QSA]
     RewriteCond         %{HTTP_USER_AGENT}      !^.*BSD.*$
     RewriteRule         ^/search/(.*)$            /search/mobile.php$1 [PT]
 
-    # senate/ URL Mobile redirection (by exclusion)
+    # senate/ URL Mobile redirection (by exclusion). !(^|&)id= excludes the single-debate
+    # transcript view (?id=<gid>, hansard_gid.php) - that's a responsive/adaptive design
+    # now (see openaustralia/twfy#227), so mobile visitors get the same page as desktop.
+    # Everything else under /senate/ (date/year listings etc.) hasn't been redesigned yet,
+    # so still gets the dedicated mobile.php as before.
     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
+    RewriteCond         %{QUERY_STRING}         !(^|&)id= [NC]
         # NOTE: May want to add other bot patters here
         RewriteCond         %{HTTP_USER_AGENT}      !^.*(spider|crawl|slurp|bot).*$ [NC]
     RewriteCond         %{HTTP_USER_AGENT}      ^.*webOS.*$ [NC,OR]
@@ -142,8 +137,11 @@ RewriteRule ^/news/index.rdf$      /news/rdf.php [QSA]
     RewriteCond         %{HTTP_USER_AGENT}      !^.*BSD.*$
     RewriteRule         ^/senate/(.*)$            /senate/mobile.php$1 [QSA]
 
-    # debates/ URL Mobile redirection (by exclusion)
+    # debates/ URL Mobile redirection (by exclusion). Same !(^|&)id= exclusion as
+    # /senate/ above, for the same reason - only the single-debate transcript view is
+    # redesigned so far.
     RewriteCond         %{QUERY_STRING}         !.*show_pc.* [NC]
+    RewriteCond         %{QUERY_STRING}         !(^|&)id= [NC]
         # NOTE: May want to add other bot patters here
         RewriteCond         %{HTTP_USER_AGENT}      !^.*(spider|crawl|slurp|bot).*$ [NC]
     RewriteCond         %{HTTP_USER_AGENT}      ^.*webOS.*$ [NC,OR]


### PR DESCRIPTION
## Description

Stacked on #228 (only touches Apache config, but part of the same redesign push and
depends on both #227 and #228's pages actually being responsive).

Smartphone visitors currently get silently rewritten away from the redesigned pages
entirely, to separate, un-redesigned `mobile.php`/`*_mobile.php` files, via User-Agent
sniffing rewrite rules in `conf/httpd.conf.ubuntu` - none of this session's redesign
work has ever been visible to an actual mobile visitor on production. This stops that
for the two pages that are now responsive/adaptive designs:

- `/` - mobile redirect removed entirely (front page, #228).
- `/senate/(.*)` and `/debates/(.*)` - redirect now excludes requests with an `id=`
  query param (the single-debate transcript view specifically, #227) via an added
  `!(^|&)id=` condition. Everything else under those prefixes (date/year listings
  etc.) hasn't been redesigned yet, so still gets the dedicated `mobile.php` as before
  - this isn't an "all mobile redirects are gone" change, just the two pages that are
    actually ready for it.
- `/help/`, `/search/`, `/mp/` mobile redirects untouched - out of scope.

`conf/httpd-docker.conf`'s commented-out reference copy of these rules updated to
match, so it doesn't drift from what production actually runs (no live effect either
way - docker's mobile redirects were already all commented out; there's no way to
exercise this rewrite-rule change locally).

Also fixes a real bug this surfaced: testing what a mobile visitor would actually see
on the transcript page (rather than the old dedicated mobile.php), the pagination
bar's three-column layout overlapped badly at narrow widths - fixed on #227 directly
(the branch that owns that file) rather than here.

## Motivation and Context

No point redesigning these pages for mobile-friendliness (they were built responsive
from the start) if mobile visitors never actually see them.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system - checked both pages
      at a 390px viewport (iPhone-sized) locally; couldn't exercise the Apache rewrite
      rule itself locally (docker's config never had these redirects active to begin
      with), so that part is reviewed by hand against the existing rule syntax, not
      tested live
- [ ] Ran automated tests on my own system - N/A, no PHP/JS changed
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots

Mobile (390px) before/after for the transcript page's pagination bar sent separately.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
