### PR TITLE
Guard against null parse_date in mobile search

### DIFF
--- a/www/docs/search/mobile.php
+++ b/www/docs/search/mobile.php
@@ -18,7 +18,7 @@ if (get_http_var('s') != '' || get_http_var('pid') != '') {
     $searchstring = filter_user_input($searchstring, 'strict');
 
     $time = parse_date($searchstring);
-    if ($time['iso']) {
+    if ($time && $time['iso']) {
         header('Location: /hansard/?d=' . $time['iso']);
         exit;
     }


### PR DESCRIPTION
## Description

One-line null guard in `www/docs/search/mobile.php`:

```diff
 $time = parse_date($searchstring);
-if ($time['iso']) {
+if ($time && $time['iso']) {
```

The block is now identical to the desktop equivalent at `www/docs/search/index.php:19-23`.

## Motivation and Context

Resolves openaustralia/openaustralia#940.

`parse_date()` in `www/includes/utility.php:408` returns `null` when the search string is empty after its filtering pass, which strips single letters and common filler words. `mobile.php` then dereferenced the result without checking it.

This is the largest single source of errors in production. Sentry [OPENAUSTRALIAORGAU-1](https://oaf-org-au.sentry.io/issues/143392135/) recorded 1077 events in the 24 hours to 2026-08-29, roughly 97% of all captured events for the site.

The guard already exists on the desktop path. It was added in d489d634 ("upgrade to mysql8 and php8 (go live)", #96) but `mobile.php` was missed, so this brings the two into line rather than introducing anything new.

Searching by speaker alone also triggers it, because the page is entered when `pid` is set even though `s` is empty.

## How Has This Been Tested?

- [x] `php -l www/docs/search/mobile.php` passes
- [x] Verified the changed block is byte-identical to the working desktop version in `www/docs/search/index.php`
- [ ] Checked affected area manually on my own / staging system
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

Not yet exercised against a running site. Worth confirming on staging that a non-date mobile search still returns results and that a date search still redirects to `/hansard/?d=`.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## AI assistance

Assisted-by: Claude Code:claude-opus-5

Claude Code triaged the open Sentry issues for OpenAustralia.org.au, identified this as the dominant error source, and wrote the change. **The commit does not yet carry a DCO `Signed-off-by` line**, since per the org CONTRIBUTING guide that sign-off must be made by a human. Add it with `git commit --amend -s && git push --force-with-lease` before taking this out of draft.
