### PR TITLE
README: only House of Representatives and Senate are real, everything else is dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 This is a fork of a 2001-ish era PHP app from MySociety in the UK, repurposed for Australia. This is the software running on https://openaustralia.org.au
 
+## Only the House of Representatives and the Senate are real
+
+The original UK app covered several legislatures - the House of Commons, the House of Lords, the
+Scottish Parliament, the Northern Ireland Assembly, Westminster Hall, Public Bill Committees. In
+this fork's code, "Lords" was renamed to "Senate" (that's expected - not a bug), and House of
+Commons became House of Representatives, but the other legislatures were never repurposed: this
+site has never populated Westminster Hall, Written Answers ("Wrans"), Written Ministerial
+Statements, the Northern Ireland Assembly, or the Scottish Parliament (debates or written
+answers) with real data, and never will.
+
+Code for all of those is still in the tree (`dbtypes.php`'s majors 2-8/104, the
+`www/docs/{whall,wrans,wms,ni,sp,spwrans,pbc,mlas,msps}/` routers, matching sidebars, and most of
+`hansardlist.php`'s list classes) - it's dead weight from the fork, not a feature anyone should
+build on. Treat it as such: don't invest effort maintaining it, and prefer removing it outright
+over updating it whenever a change already touches it. See
+[openaustralia/openaustralia#945](https://github.com/openaustralia/openaustralia/issues/945) for
+the tracked removal.
+
 ## What is OpenAustralia.org.au ?
 
 OpenAustralia.org.au is a website run by the non-partisan charity, OpenAustralia Foundation, which makes Australian government and parliamentary information easily accessible to the public through tools such as searching Hansard (parliamentary debates) and tracking politicians' voting records. The site aims to increase transparency and civic engagement in Australian democracy. It provides platforms to easily follow what MPs and Senators say and do, and tracks their registers of interests.


### PR DESCRIPTION
## Description

Adds a short section near the top of the README stating plainly which legislatures this fork
actually supports (House of Representatives, Senate) versus which ones are inherited dead code
from the original UK app (Westminster Hall, Wrans, WMS, NI Assembly, Scottish Parliament) that's
never been populated with real data and never will be.

## Motivation and Context

This keeps coming up while working on the codebase - several recent PR descriptions have had to
explicitly carve out "everything except major 1/101" as out of scope, and it's easy for a new
contributor (or an AI agent) to reasonably wonder whether the site actually handles Scottish
Parliament debates before realising it doesn't. Points at
openaustralia/openaustralia#945 for the tracked removal, and states the interim policy: don't
maintain this code, prefer removing it outright over updating it whenever a change already
touches it.

## How Has This Been Tested?

- [x] Docs-only change, no code affected

## Types of Changes

- [x] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)