### PR TITLE
Replace dead Google Analytics with Plausible.io

### DIFF
--- a/conf/general-docker
+++ b/conf/general-docker
@@ -49,6 +49,13 @@ define ("DEBUGTAG", 'debug');
 define ("SENTRY_DSN", "");
 define ("SENTRY_ENVIRONMENT", "development");
 
+// Plausible.io analytics script identifier (the "pa-..." fragment of
+// https://plausible.io/js/pa-....js, from Plausible's own dashboard) - not a
+// secret, but empty by default so PlausibleView::renderTag() stays disabled.
+// Staging/production get the real value templated in from infrastructure's
+// plausible_script_id (group_vars/openaustralia.yml).
+define ("PLAUSIBLE_SCRIPT_ID", "");
+
 // Timezone (only works in PHP5)
 define ("TIMEZONE", "Australia/Sydney");
 

--- a/conf/general-example.local-dev
+++ b/conf/general-example.local-dev
@@ -53,6 +53,15 @@ define ("DEBUGTAG", 'debug');
 define ("SENTRY_DSN", "");
 define ("SENTRY_ENVIRONMENT", "development");
 
+// Plausible.io analytics script identifier (the "pa-..." fragment of
+// https://plausible.io/js/pa-....js, from Plausible's own dashboard) - not a
+// secret (it's already public in every page's own HTML), but empty by default
+// in local dev so PlausibleView::renderTag() stays disabled (page.php's
+// page_header()/page_header_mobile() only ever gate on DEVSITE anyway, so this
+// is belt-and-braces). Staging/production get the real value templated in
+// from infrastructure's plausible_script_id (group_vars/openaustralia.yml).
+define ("PLAUSIBLE_SCRIPT_ID", "");
+
 // Timezone (only works in PHP5)
 define ("TIMEZONE", "Australia/Sydney");
 

--- a/conf/general-example.local-dev
+++ b/conf/general-example.local-dev
@@ -56,10 +56,12 @@ define ("SENTRY_ENVIRONMENT", "development");
 // Plausible.io analytics script identifier (the "pa-..." fragment of
 // https://plausible.io/js/pa-....js, from Plausible's own dashboard) - not a
 // secret (it's already public in every page's own HTML), but empty by default
-// in local dev so PlausibleView::renderTag() stays disabled (page.php's
-// page_header()/page_header_mobile() only ever gate on DEVSITE anyway, so this
-// is belt-and-braces). Staging/production get the real value templated in
-// from infrastructure's plausible_script_id (group_vars/openaustralia.yml).
+// in local dev so PlausibleView::renderTag() stays disabled. Not just
+// belt-and-braces: tests/PageRenderingIntegrationTestCase.php writes a
+// conf/general that omits this constant entirely, so the defined() guard in
+// page.php is what stops those integration tests fataling. Staging/production
+// get the real value templated in from infrastructure's plausible_script_id
+// (group_vars/openaustralia.yml).
 define ("PLAUSIBLE_SCRIPT_ID", "");
 
 // Timezone (only works in PHP5)

--- a/conf/general-example.mac
+++ b/conf/general-example.mac
@@ -49,6 +49,13 @@ define ("DEBUGTAG", 'debug');
 define ("SENTRY_DSN", "");
 define ("SENTRY_ENVIRONMENT", "development");
 
+// Plausible.io analytics script identifier (the "pa-..." fragment of
+// https://plausible.io/js/pa-....js, from Plausible's own dashboard) - not a
+// secret, but empty by default so PlausibleView::renderTag() stays disabled.
+// Staging/production get the real value templated in from infrastructure's
+// plausible_script_id (group_vars/openaustralia.yml).
+define ("PLAUSIBLE_SCRIPT_ID", "");
+
 // Timezone (only works in PHP5)
 define ("TIMEZONE", "Australia/Sydney");
 

--- a/conf/general-example.ubuntu
+++ b/conf/general-example.ubuntu
@@ -49,6 +49,13 @@ define ("DEBUGTAG", 'debug');
 define ("SENTRY_DSN", "");
 define ("SENTRY_ENVIRONMENT", "development");
 
+// Plausible.io analytics script identifier (the "pa-..." fragment of
+// https://plausible.io/js/pa-....js, from Plausible's own dashboard) - not a
+// secret, but empty by default so PlausibleView::renderTag() stays disabled.
+// Staging/production get the real value templated in from infrastructure's
+// plausible_script_id (group_vars/openaustralia.yml).
+define ("PLAUSIBLE_SCRIPT_ID", "");
+
 // Timezone (only works in PHP5)
 define ("TIMEZONE", "Australia/Sydney");
 

--- a/tests/HelpPageStaticContentTest.php
+++ b/tests/HelpPageStaticContentTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+/**
+ * staticpages/help.php is plain markup with no wrapping function, so it's
+ * simplest to include it directly and check the rendered text, rather than
+ * going through a full (and, for this file, coverage-blind - see
+ * PageHeaderAnalyticsTest.php) page render.
+ */
+class HelpPageStaticContentTest extends TestCase {
+
+    /**
+     *
+     */
+    public function test_help_page_mentions_plausible_not_google_analytics() {
+        ob_start();
+        include_once __DIR__ . '/../www/includes/easyparliament/staticpages/help.php';
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('Plausible', $html);
+        $this->assertStringNotContainsString('urchin', $html);
+    }
+
+}

--- a/tests/PageHeaderAnalyticsTest.php
+++ b/tests/PageHeaderAnalyticsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../www/includes/data.php';
+require_once __DIR__ . '/../www/includes/easyparliament/skin.php';
+require_once __DIR__ . '/../www/includes/easyparliament/page.php';
+
+// utility.php can't be required here - it redeclares twfy_debug(), already
+// stubbed in bootstrap.php for the rest of the unit suite. get_http_var()
+// (SKIN's constructor calls it) is the one function from there page_header()
+// actually needs, so it's stubbed the same way bootstrap.php stubs the rest.
+if (!function_exists('get_http_var')) {
+
+    function get_http_var($name, $default = '') {
+        return $_GET[$name] ?? $_POST[$name] ?? $default;
+    }
+
+}
+
+if (!defined('DEVSITE')) {
+    define('DEVSITE', false);
+}
+if (!defined('PLAUSIBLE_SCRIPT_ID')) {
+    define('PLAUSIBLE_SCRIPT_ID', 'pa-test123');
+}
+if (!defined('CONTACTEMAIL')) {
+    define('CONTACTEMAIL', 'contact@example.com');
+}
+if (!defined('DOMAIN')) {
+    define('DOMAIN', 'example.com');
+}
+
+/**
+ * page_header()'s analytics_tag() call site can't be covered by
+ * PageRenderingIntegrationTestCase's subprocess-based tests (eg
+ * IndexPageIntegrationTest) - those render the page with proc_open in a
+ * separate PHP process, and code coverage never crosses that boundary back
+ * to PHPUnit. DATA and SKIN are both file-based with no DB dependency, so
+ * PAGE::page_header() can be called directly here instead, in-process,
+ * where coverage actually gets recorded. DEVSITE/PLAUSIBLE_SCRIPT_ID are
+ * real constants here (not parameters, unlike PlausibleView::renderTag()
+ * itself - see PlausibleViewTest.php for why), so this only exercises one
+ * branch; that's fine, since renderTag()'s own branches are already fully
+ * covered there.
+ */
+class PageHeaderAnalyticsTest extends TestCase {
+
+    /**
+     *
+     */
+    public function test_page_header_includes_the_plausible_tag() {
+        global $this_page, $DATA;
+        $this_page = 'home';
+        $DATA = new DATA();
+
+        $page = new PAGE();
+        ob_start();
+        $page->page_header();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('plausible.io/js/pa-test123.js', $html);
+    }
+
+}

--- a/tests/PlausibleViewTest.php
+++ b/tests/PlausibleViewTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @file
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../www/includes/easyparliament/PlausibleView.php';
+
+/**
+ * PlausibleView (see www/includes/easyparliament/page.php's page_header()/
+ * page_header_mobile()) is pure decision logic for the Plausible.io analytics tag -
+ * no echo, no globals, so it's directly testable. See that class's own comment for
+ * why DEVSITE/PLAUSIBLE_SCRIPT_ID have to be passed in as plain parameters rather
+ * than read directly for this to be possible at all.
+ */
+class PlausibleViewTest extends TestCase {
+
+    /**
+     *
+     */
+    public function test_renderTag_returns_an_empty_string_on_a_dev_site_even_with_a_script_id() {
+        $this->assertSame('', PlausibleView::renderTag(true, 'pa-eMxq8hHU91Qjn6D5vwWZa'));
+    }
+
+    /**
+     *
+     */
+    public function test_renderTag_returns_an_empty_string_when_there_is_no_script_id() {
+        $this->assertSame('', PlausibleView::renderTag(false, ''));
+    }
+
+    /**
+     * The one branch an inline check against the real DEVSITE/PLAUSIBLE_SCRIPT_ID
+     * constants could never reach in a test (see this class's own comment) - not
+     * dev, script id present.
+     */
+    public function test_renderTag_renders_the_script_src_and_init_call() {
+        $tag = PlausibleView::renderTag(false, 'pa-eMxq8hHU91Qjn6D5vwWZa');
+
+        $this->assertStringContainsString('src="https://plausible.io/js/pa-eMxq8hHU91Qjn6D5vwWZa.js"', $tag);
+        $this->assertStringContainsString('plausible.init()', $tag);
+    }
+
+    /**
+     * $scriptId ends up in an HTML attribute - htmlspecialchars(), same convention
+     * as SentryBrowserView::loaderScriptUrl()'s own src="" handling, in case it
+     * ever contains characters that would break out of the attribute (unlikely for
+     * a Plausible-issued id, but cheap insurance).
+     */
+    public function test_renderTag_escapes_the_script_id_for_the_html_attribute() {
+        $tag = PlausibleView::renderTag(false, 'pa-"><script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('"><script>alert(1)</script>', $tag);
+        $this->assertStringContainsString('&quot;&gt;', $tag);
+    }
+
+}

--- a/tests/PlausibleViewTest.php
+++ b/tests/PlausibleViewTest.php
@@ -45,10 +45,11 @@ class PlausibleViewTest extends TestCase {
     }
 
     /**
-     * $scriptId ends up in an HTML attribute - htmlspecialchars(), same convention
-     * as SentryBrowserView::loaderScriptUrl()'s own src="" handling, in case it
-     * ever contains characters that would break out of the attribute (unlikely for
-     * a Plausible-issued id, but cheap insurance).
+     * $scriptId ends up in an HTML attribute, so renderTag() runs it through
+     * htmlspecialchars() in case it ever contains characters that would break out
+     * of the attribute (unlikely for a Plausible-issued id, but cheap insurance).
+     * On PHP 8.1+ the default flags include ENT_QUOTES, which is what makes the
+     * &quot; assertion below hold - composer.json pins ^8.3.0, so it does.
      */
     public function test_renderTag_escapes_the_script_id_for_the_html_attribute() {
         $tag = PlausibleView::renderTag(false, 'pa-"><script>alert(1)</script>');

--- a/www/includes/easyparliament/PlausibleView.php
+++ b/www/includes/easyparliament/PlausibleView.php
@@ -4,11 +4,11 @@
  * @file
  * Whether/how to render the Plausible.io analytics tag (page.php's page_header()/
  * page_header_mobile()) - pure logic and markup building, no echo of its own, so
- * it's directly testable without $PAGE/$DATA or a full page render. Same split as
- * SentryBrowserView.php (page.php's own browser error tracking) - see that file's
- * own comment for why DEVSITE/PLAUSIBLE_SCRIPT_ID have to reach here as plain
- * parameters rather than being read directly: they're define()'d once from
- * conf/general at bootstrap and can't be toggled per-test.
+ * it's directly testable without $PAGE/$DATA or a full page render. DEVSITE and
+ * PLAUSIBLE_SCRIPT_ID have to reach here as plain parameters rather than being
+ * read directly: they're define()'d once from conf/general at bootstrap and so
+ * can't be toggled per-test, which would leave the "render the tag" branch of an
+ * inline check in page_header() permanently unreachable from a test.
  *
  * Plausible Cloud (not the self-hosted option - see openaustralia/infrastructure#547,
  * which removed a self-hosted module that was never actually used) needs nothing

--- a/www/includes/easyparliament/PlausibleView.php
+++ b/www/includes/easyparliament/PlausibleView.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Whether/how to render the Plausible.io analytics tag (page.php's page_header()/
+ * page_header_mobile()) - pure logic and markup building, no echo of its own, so
+ * it's directly testable without $PAGE/$DATA or a full page render. Same split as
+ * SentryBrowserView.php (page.php's own browser error tracking) - see that file's
+ * own comment for why DEVSITE/PLAUSIBLE_SCRIPT_ID have to reach here as plain
+ * parameters rather than being read directly: they're define()'d once from
+ * conf/general at bootstrap and can't be toggled per-test.
+ *
+ * Plausible Cloud (not the self-hosted option - see openaustralia/infrastructure#547,
+ * which removed a self-hosted module that was never actually used) needs nothing
+ * secret to embed. $scriptId is the site-specific fragment of the script URL
+ * Plausible's own dashboard generates (eg "pa-eMxq8hHU91Qjn6D5vwWZa" from
+ * "https://plausible.io/js/pa-eMxq8hHU91Qjn6D5vwWZa.js") - it identifies which
+ * site's dashboard events land in, same "public, not a secret" status as Sentry's
+ * DSN public key, since it's already embedded in every page's own HTML/script src.
+ */
+
+/**
+ *
+ */
+class PlausibleView {
+
+    /**
+     * The complete <script> tags for page_header()'s/page_header_mobile()'s
+     * <head> - empty string on a dev site or when PLAUSIBLE_SCRIPT_ID isn't
+     * configured yet (empty string - safe default until a human registers the
+     * site in Plausible's dashboard and sets openaustralia/infrastructure's
+     * plausible_script_id).
+     */
+    public static function renderTag(bool $devsite, string $scriptId): string {
+        if ($devsite || !$scriptId) {
+            return '';
+        }
+
+        return '<script async src="https://plausible.io/js/' . htmlspecialchars($scriptId) . '.js"></script>'
+            . '<script>'
+            . 'window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};'
+            . 'plausible.init()'
+            . '</script>';
+    }
+
+}

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -10,6 +10,7 @@ if (defined('OPTION_TRACKING') && OPTION_TRACKING) {
 
 include_once __DIR__ . '/member.php';
 include_once __DIR__ . '/../request.php';
+include_once __DIR__ . '/PlausibleView.php';
 
 /**
  *
@@ -328,20 +329,13 @@ class PAGE {
                 <?php
             }
 
-            if (!DEVSITE) {
-                ?>
-
-                <script type="text/javascript">
-                    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-                    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-                </script>
-                <script type="text/javascript">
-                    var pageTracker = _gat._getTracker("UA-3107958-3");
-                    pageTracker._initData();
-                    pageTracker._trackPageview();
-                </script>
-
-            <?php } ?>
+            // Was Google Analytics Classic (ga.js, UA-3107958-3) - dead since
+            // Google fully sunset every Universal Analytics property (any "UA-"
+            // one) on 1 July 2024, ga.js itself long before that. Replaced with
+            // Plausible.io Cloud - see PlausibleView.php's own comment for why
+            // this needs no secret, just PLAUSIBLE_SCRIPT_ID.
+            echo PlausibleView::renderTag(DEVSITE, defined('PLAUSIBLE_SCRIPT_ID') ? PLAUSIBLE_SCRIPT_ID : '');
+            ?>
 
         </head>
 
@@ -465,20 +459,13 @@ class PAGE {
                 <?php
             }
 
-            if (!DEVSITE) {
-                ?>
-
-                <script type="text/javascript">
-                    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-                    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-                </script>
-                <script type="text/javascript">
-                    var pageTracker = _gat._getTracker("UA-3107958-3");
-                    pageTracker._initData();
-                    pageTracker._trackPageview();
-                </script>
-
-            <?php } ?>
+            // Was Google Analytics Classic (ga.js, UA-3107958-3) - dead since
+            // Google fully sunset every Universal Analytics property (any "UA-"
+            // one) on 1 July 2024, ga.js itself long before that. Replaced with
+            // Plausible.io Cloud - see PlausibleView.php's own comment for why
+            // this needs no secret, just PLAUSIBLE_SCRIPT_ID.
+            echo PlausibleView::renderTag(DEVSITE, defined('PLAUSIBLE_SCRIPT_ID') ? PLAUSIBLE_SCRIPT_ID : '');
+            ?>
 
         </head>
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -329,17 +329,24 @@ class PAGE {
                 <?php
             }
 
-            // Was Google Analytics Classic (ga.js, UA-3107958-3) - dead since
-            // Google fully sunset every Universal Analytics property (any "UA-"
-            // one) on 1 July 2024, ga.js itself long before that. Replaced with
-            // Plausible.io Cloud - see PlausibleView.php's own comment for why
-            // this needs no secret, just PLAUSIBLE_SCRIPT_ID.
-            echo PlausibleView::renderTag(DEVSITE, defined('PLAUSIBLE_SCRIPT_ID') ? PLAUSIBLE_SCRIPT_ID : '');
+            echo $this->analytics_tag();
             ?>
 
         </head>
 
         <?php
+    }
+
+    /**
+     * The analytics tag for page_header()'s/page_header_mobile()'s <head>.
+     * Was Google Analytics Classic (ga.js, UA-3107958-3) - dead since Google
+     * fully sunset every Universal Analytics property (any "UA-" one) on
+     * 1 July 2024, ga.js itself long before that. Replaced with Plausible.io
+     * Cloud - see PlausibleView.php's own comment for why this needs no
+     * secret, just PLAUSIBLE_SCRIPT_ID.
+     */
+    private function analytics_tag(): string {
+        return PlausibleView::renderTag(DEVSITE, defined('PLAUSIBLE_SCRIPT_ID') ? PLAUSIBLE_SCRIPT_ID : '');
     }
 
     /**
@@ -459,12 +466,7 @@ class PAGE {
                 <?php
             }
 
-            // Was Google Analytics Classic (ga.js, UA-3107958-3) - dead since
-            // Google fully sunset every Universal Analytics property (any "UA-"
-            // one) on 1 July 2024, ga.js itself long before that. Replaced with
-            // Plausible.io Cloud - see PlausibleView.php's own comment for why
-            // this needs no secret, just PLAUSIBLE_SCRIPT_ID.
-            echo PlausibleView::renderTag(DEVSITE, defined('PLAUSIBLE_SCRIPT_ID') ? PLAUSIBLE_SCRIPT_ID : '');
+            echo $this->analytics_tag();
             ?>
 
         </head>

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -78,11 +78,11 @@
     <!-- start new faq entry -->
     <dt><a name="extreme"></a>What's that Plausible script I spy in your page source?</dt>
     <dd>
-        <p>We use <a href="https://plausible.io">Plausible</a>, a privacy-friendly analytics tool, to track
+        <p>We use <a href="https://plausible.io" rel="nofollow noreferrer noopener" target="_blank">Plausible</a>, a privacy-friendly analytics tool, to track
             aggregated traffic through the website - which pages get visited, and how many people are visiting.
-            Unlike Google Analytics, which we used to run, Plausible doesn't use cookies and doesn't collect or
-            store any personal data about you. We only track usage data for one reason: to help us understand how
-            we can make the site work better for you lot.</p>
+            Unlike Google Analytics, which we used to run, Plausible doesn't use cookies, doesn't track you
+            across other websites, and doesn't store your IP address or build any profile of you. We only track
+            usage data for one reason: to help us understand how we can make the site work better for you lot.</p>
     </dd>
     <!-- end old faq entry -->
 

--- a/www/includes/easyparliament/staticpages/help.php
+++ b/www/includes/easyparliament/staticpages/help.php
@@ -9,7 +9,7 @@
     <li><a href="#missing">Is this the whole of Hansard?</a></li>
     <li><a href="#privacy">What is your Privacy Policy?</a></li>
     <li><a href="#cookie">What is your Cookie Policy?</a></li>
-    <li><a href="#extreme">What's that weird 'urchin' javascript I spy in your page source?</a></li>
+    <li><a href="#extreme">What's that Plausible script I spy in your page source?</a></li>
     <li><a href="#rss">What is RSS?</a></li>
     <li><a href="#votingrecord">How is the voting record decided?</a></li>
     <li><a href="#numbers">Why should I read in more depth than just the numbers?</a></li>
@@ -76,12 +76,13 @@
 
 
     <!-- start new faq entry -->
-    <dt><a name="extreme"></a>What's that weird 'urchin' javascript I spy in your page source?</dt>
+    <dt><a name="extreme"></a>What's that Plausible script I spy in your page source?</dt>
     <dd>
-        <p>We use Google Analytics to track aggregated traffic through the website. It captures nothing that you won't
-            find in an Apache logfile, but has an interface we like, and is dead easy to use. Rest assured, we only
-            track usage data for one reason only: to help us understand how we can make the site work better for you
-            lot. If anyone wants to whinge about 'Web Bugs', expect short shrift. </p>
+        <p>We use <a href="https://plausible.io">Plausible</a>, a privacy-friendly analytics tool, to track
+            aggregated traffic through the website - which pages get visited, and how many people are visiting.
+            Unlike Google Analytics, which we used to run, Plausible doesn't use cookies and doesn't collect or
+            store any personal data about you. We only track usage data for one reason: to help us understand how
+            we can make the site work better for you lot.</p>
     </dd>
     <!-- end old faq entry -->
 


### PR DESCRIPTION
## What

Replaces the dead Google Analytics Classic snippet (`ga.js`, property `UA-3107958-3`) with Plausible.io Cloud.

The GA snippet was still being served on every page in production (gated on `!DEVSITE`), but has produced zero actual data since Google fully sunset every Universal Analytics property (any `UA-`-prefixed one, including this site's) on 1 July 2024 - `ga.js` itself was dead well before that, since ~2012.

## Why Plausible

See openaustralia/infrastructure#547, which removed a self-hosted Plausible module that was never actually used - confirming Plausible.io **Cloud** is the intended direction, not self-hosting. Cloud needs no secret to embed: just a site-specific script identifier from Plausible's own dashboard, which is already public (it's embedded directly in every page's own HTML/script `src`).

## Changes

- New `PlausibleView::renderTag()` - same split as `SentryBrowserView.php` (pure decision logic, no echo/globals of its own, directly testable). Wired into both `page_header()` **and** `page_header_mobile()` - unlike Sentry's browser error tracking (desktop-only), visit analytics should count all traffic.
- `PLAUSIBLE_SCRIPT_ID` documented in `conf/general-example.local-dev` and `conf/general-docker`, empty by default (safe/disabled - matches `SENTRY_DSN`'s own established "unconfigured is safe" pattern).
- `help.php`'s FAQ entry about "that weird 'urchin' javascript" updated to describe Plausible instead - both the table-of-contents link and the answer, which now actually reassures on the privacy point (no cookies, no personal data collected) rather than dismissing it as "Web Bugs" whinging, matching what Plausible genuinely does differently from GA.

## Before merging

Needs a companion infrastructure PR (not yet opened) to add the real `plausible_script_id` value to `group_vars/openaustralia.yml` + `roles/internal/openaustralia/templates/general.j2`, mirroring how `sentry_browser_public_key` was added for browser Sentry tracking. Safe to merge before that lands - `PLAUSIBLE_SCRIPT_ID` defaults to empty (disabled) until it's set.

## Verification

- Full unit suite (256 tests) green, phpcs clean.
- Live-verified in Docker: rendered tag matches Plausible's own dashboard-generated snippet exactly.
- Live-verified the updated help page copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
