### PR TITLE
Disable SonarCloud's camelCase naming rule for legacy snake_case code

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,9 +12,16 @@ sonar.php.codesniffer.reportPaths=coverage/phpcs.xml
 
 # PHPCS (Drupal/Generic.PHP.UpperCaseConstant) requires TRUE/FALSE/NULL uppercase.
 # Disable conflicting Sonar PHP rule that enforces lowercase keywords/constants.
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2
 sonar.issue.ignore.multicriteria.e1.ruleKey=php:S1781
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.php
+
+# phpcs.xml deliberately disables Drupal.NamingConventions.ValidFunctionName/
+# ValidVariableName to allow this codebase's own long-established snake_case
+# convention (most function/variable names throughout www/includes/). Disable
+# the conflicting Sonar PHP rule that requires camelCase.
+sonar.issue.ignore.multicriteria.e2.ruleKey=php:S100
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.php
 
 sonar.exclusions=vendor/**,node_modules/**,**/test/**
 sonar.test.exclusions=vendor/**,node_modules/**


### PR DESCRIPTION
## Description

Adds a second `sonar.issue.ignore.multicriteria` entry to `sonar-project.properties`, disabling SonarCloud's `php:S100` naming-convention rule (requires camelCase) project-wide.

## Motivation and Context

`phpcs.xml` already deliberately disables the equivalent PHPCS sniffs (`Drupal.NamingConventions.ValidFunctionName`/`ValidVariableName`) to allow this codebase's own long-established snake_case convention throughout `www/includes/`. SonarCloud's own PHP analyser doesn't read `phpcs.xml`, so it was independently flagging the same names as violations - `context_link()` was flagged this way on #227 (discussed with @ianheggie-oaf and @Br3nda there). Same class of fix already applied for `php:S1781` (lowercase `TRUE`/`FALSE`/`NULL`) just above it in the same file.

## How Has This Been Tested?

- [x] Config-only change - no application code touched.
- [x] Confirmed it passed the GitHub actions tests

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code:claude-sonnet-5