### PR TITLE
Tag Sentry events with the deployed commit SHA

### DIFF
--- a/www/includes/easyparliament/init.php
+++ b/www/includes/easyparliament/init.php
@@ -74,11 +74,14 @@ if (defined('SENTRY_DSN') && SENTRY_DSN) {
     // sentry-ruby's auto-detection from Capistrano's own REVISION file (that's
     // a Rails-integration-specific convenience), so read it directly; absent
     // in local dev, where there's nothing to read.
-    $revisionFile = __DIR__ . '/../../../REVISION';
-    if (is_readable($revisionFile)) {
-        $revision = trim(file_get_contents($revisionFile));
-        if ($revision !== '') {
-            $sentryOptions['release'] = $revision;
+    $revision_file = __DIR__ . '/../../../REVISION';
+    if (is_readable($revision_file)) {
+        $revision_contents = file_get_contents($revision_file);
+        if ($revision_contents !== false) {
+            $revision = trim($revision_contents);
+            if ($revision !== '') {
+                $sentryOptions['release'] = $revision;
+            }
         }
     }
 

--- a/www/includes/easyparliament/init.php
+++ b/www/includes/easyparliament/init.php
@@ -61,10 +61,28 @@ $old_error_handler = set_error_handler("error_handler");
 // by default chains to whatever was already registered, so error_handler
 // above still runs as before - this adds reporting, it doesn't replace it.
 if (defined('SENTRY_DSN') && SENTRY_DSN) {
-    \Sentry\init([
+    $sentryOptions = [
         'dsn' => SENTRY_DSN,
         'environment' => defined('SENTRY_ENVIRONMENT') ? SENTRY_ENVIRONMENT : 'development',
-    ]);
+    ];
+
+    // 'release': the exact commit SHA of this deploy, so Sentry can tell which
+    // version introduced/fixed an error and group events accordingly. Written
+    // by the umbrella repo's Capfile (git:create_release) as this submodule's
+    // own HEAD, not the umbrella repo's own commit - the two can differ, and
+    // it's this repo's code that actually runs. No PHP equivalent of
+    // sentry-ruby's auto-detection from Capistrano's own REVISION file (that's
+    // a Rails-integration-specific convenience), so read it directly; absent
+    // in local dev, where there's nothing to read.
+    $revisionFile = __DIR__ . '/../../../REVISION';
+    if (is_readable($revisionFile)) {
+        $revision = trim(file_get_contents($revisionFile));
+        if ($revision !== '') {
+            $sentryOptions['release'] = $revision;
+        }
+    }
+
+    \Sentry\init($sentryOptions);
 }
 
 // The time the page starts, so we can display the total at the end.


### PR DESCRIPTION
## Description

Adds a `release` value to Sentry's `\Sentry\init()` call in `init.php`, read from a `REVISION` file at the repo root - so captured errors can be grouped/tracked against the exact deployed commit, instead of landing with no version info at all.

## Motivation and Context

Sentry could already receive errors (`dsn`/`environment` were already configured), but had no way to tell which version of the code produced a given one. `theyvoteforyou`'s own Sentry integration already does this - `sentry-ruby` auto-detects the release from Capistrano's own `REVISION` file, no config needed. There's no PHP-SDK equivalent of that auto-detection, so this reads the file directly instead.

This needs a matching change on the umbrella repo's side to actually *write* that file - see [openaustralia/openaustralia#956](https://github.com/openaustralia/openaustralia/pull/956), opened alongside this one. Specifically it needs to be *this submodule's own* commit SHA, not the umbrella repo's own commit (Capistrano's default `deploy:set_current_revision` would capture the latter, and doesn't currently run correctly here anyway - see that PR's description for why).

Degrades safely without the file present (eg local dev, or before the umbrella-repo PR lands): `release` is simply omitted from the Sentry options, identical to today's behaviour.

## How Has This Been Tested?

- [x] Ran automated tests on my own system - `php -l`, `phpcs`, full `phpunit` suite (258 tests; the only 3 failures are a pre-existing, unrelated local-DB-state issue in `SearchLogTest`, reproducible in isolation with no relation to this change)
- [x] Verified the exact read/trim/fallback logic in isolation against both a present and absent `REVISION` file
- [x] Confirmed the local dev site still renders correctly (200, no PHP warnings/errors) with this change live
- [ ] Confirmed it passed the GitHub actions tests

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code:claude-sonnet-5