### PR TITLE
Track email and DB query volume in Sentry

### DIFF
--- a/tests/MySQLIntegrationTest.php
+++ b/tests/MySQLIntegrationTest.php
@@ -191,4 +191,32 @@ class MySQLIntegrationTest extends DatabaseIntegrationTestCase
         $this->assertSame(1, $q->rows());
         $this->assertSame('Ivy', $q->field(0, 'name'));
     }
+
+    // -------------------------------------------------------------------------
+    // Sentry span wrapping (mysql.php) - both branches of "is there an
+    // active transaction to attach a span to".
+    // -------------------------------------------------------------------------
+
+    public function test_query_works_with_no_active_sentry_span(): void
+    {
+        $this->assertNull(\Sentry\SentrySdk::getCurrentHub()->getSpan());
+
+        $q = $this->db->query("INSERT INTO test_users (name) VALUES (?)", 'Jack');
+
+        $this->assertTrue($q->success());
+    }
+
+    public function test_query_works_with_an_active_sentry_span(): void
+    {
+        $hub = \Sentry\SentrySdk::getCurrentHub();
+        $transaction = new \Sentry\Tracing\Transaction(new \Sentry\Tracing\TransactionContext('test'), $hub);
+        $hub->setSpan($transaction);
+
+        try {
+            $q = $this->db->query("INSERT INTO test_users (name) VALUES (?)", 'Kate');
+            $this->assertTrue($q->success());
+        } finally {
+            $hub->setSpan(null);
+        }
+    }
 }

--- a/tests/MySQLTest.php
+++ b/tests/MySQLTest.php
@@ -34,6 +34,13 @@ class TestableMySQL extends MySQL {
         return $this->build_parameterized_sql($sql, $params);
     }
 
+    /**
+     *
+     */
+    public function span_description(string $sql): string {
+        return $this->sql_span_description($sql);
+    }
+
 }
 
 /**
@@ -129,7 +136,7 @@ class MySQLTest extends TestCase {
         $badness = "' OR '1'='1";
         $sql = $this->db->interpolate('WHERE email=?', [$badness]);
         $expected_escaped = "\' OR \'1\'=\'1";
-        $this->assertSame("WHERE email='".$expected_escaped."'", $sql);
+        $this->assertSame("WHERE email='" . $expected_escaped . "'", $sql);
     }
 
     /**
@@ -186,6 +193,76 @@ class MySQLTest extends TestCase {
     public function test_sql_with_no_placeholders_is_unchanged(): void {
         $sql = $this->db->interpolate('SELECT 1', []);
         $this->assertSame('SELECT 1', $sql);
+    }
+
+    // -------------------------------------------------------------------------
+    // sql_span_description() - must never leak literal query values into the
+    // Sentry span it labels.
+
+    /**
+     *
+     */
+    public function test_span_description_for_select_names_the_table(): void {
+        $sql = "SELECT * FROM member WHERE email='alice@example.com'";
+        $this->assertSame('SELECT member', $this->db->span_description($sql));
+    }
+
+    /**
+     * A literal value containing the word "FROM" must not be mistaken for
+     * the real FROM clause.
+     */
+    public function test_span_description_ignores_from_inside_a_literal_value(): void {
+        $sql = "SELECT id FROM comments WHERE body='FROM the heart, I love you'";
+        $this->assertSame('SELECT comments', $this->db->span_description($sql));
+    }
+
+    /**
+     *
+     */
+    public function test_span_description_for_insert_names_the_table(): void {
+        $sql = "INSERT INTO hansard (epobject_id, gid) VALUES (1, '2026-01-01.1.1')";
+        $this->assertSame('INSERT hansard', $this->db->span_description($sql));
+    }
+
+    /**
+     *
+     */
+    public function test_span_description_for_replace_names_the_table(): void {
+        $sql = 'REPLACE INTO postcode_lookup (postcode, name) VALUES (1, 2)';
+        $this->assertSame('REPLACE postcode_lookup', $this->db->span_description($sql));
+    }
+
+    /**
+     *
+     */
+    public function test_span_description_for_update_names_the_table(): void {
+        $sql = "UPDATE alerts SET email='foo@bar.com' WHERE alert_id=5";
+        $this->assertSame('UPDATE alerts', $this->db->span_description($sql));
+    }
+
+    /**
+     *
+     */
+    public function test_span_description_for_delete_names_the_table(): void {
+        $sql = "DELETE FROM search_query_log WHERE ip_address='1.2.3.4'";
+        $this->assertSame('DELETE search_query_log', $this->db->span_description($sql));
+    }
+
+    /**
+     *
+     */
+    public function test_span_description_for_unrecognised_verb_falls_back_to_the_verb(): void {
+        $this->assertSame('SHOW', $this->db->span_description('SHOW TABLES'));
+    }
+
+    /**
+     *
+     */
+    public function test_span_description_never_contains_a_literal_parameter_value(): void {
+        $secret = 'super-secret-search-term@example.com';
+        $sql = $this->db->interpolate('SELECT * FROM search_query_log WHERE query_string=?', [$secret]);
+
+        $this->assertStringNotContainsString($secret, $this->db->span_description($sql));
     }
 
 }

--- a/www/includes/easyparliament/init.php
+++ b/www/includes/easyparliament/init.php
@@ -5,6 +5,9 @@
  * First some things to help make our PHP nicer and betterer.
  */
 
+use Sentry\SentrySdk;
+use Sentry\Tracing\TransactionContext;
+
 error_reporting(E_ALL);
 ini_set('memory_limit', 32 * 1024 * 1024);
 
@@ -64,7 +67,32 @@ if (defined('SENTRY_DSN') && SENTRY_DSN) {
     \Sentry\init([
         'dsn' => SENTRY_DSN,
         'environment' => defined('SENTRY_ENVIRONMENT') ? SENTRY_ENVIRONMENT : 'development',
+        // Off (0) by default in this SDK. 10%, not 100%: this is a public,
+        // fairly high-traffic site, and a transaction is sent to Sentry on
+        // every sampled request - full sampling risks the account's
+        // transaction quota. 10% still gives a representative statistical
+        // view of DB query volume/latency (mysql.php's MySQL::query()).
+        // send_email() (utility.php) starts its own transaction regardless
+        // of this rate - email sending is comparatively rare, and we want
+        // every send counted, not a sample of them.
+        'traces_sample_rate' => 0.1,
     ]);
+
+    // One transaction per request (web page or CLI script - alertmailer.php
+    // and other scripts/*.php all include this file too), so DB query spans
+    // have a parent to attach to; \Sentry\trace() is a no-op with no active
+    // transaction. SCRIPT_NAME (eg "/mp/index.php"), not REQUEST_URI: the
+    // latter includes query strings/IDs, which would give every request its
+    // own transaction *name* instead of grouping same-page requests together.
+    $sentryTransactionContext = new TransactionContext(
+        PHP_SAPI === 'cli' ? ($_SERVER['argv'][0] ?? 'cli') : ($_SERVER['SCRIPT_NAME'] ?? 'unknown')
+    );
+    $sentryTransactionContext->setOp(PHP_SAPI === 'cli' ? 'cli.script' : 'http.server');
+    $sentryRequestTransaction = \Sentry\startTransaction($sentryTransactionContext);
+    SentrySdk::getCurrentHub()->setSpan($sentryRequestTransaction);
+    register_shutdown_function(function () use ($sentryRequestTransaction) {
+        $sentryRequestTransaction->finish();
+    });
 }
 
 // The time the page starts, so we can display the total at the end.

--- a/www/includes/mysql.php
+++ b/www/includes/mysql.php
@@ -100,6 +100,7 @@
  * $q->affected_rows() returns NULL.
  */
 
+use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
 
 // We'll add up the times of each query so we can output the page total at the end.
@@ -435,13 +436,19 @@ class MySQL {
         $q = new MySQLQuery($this->conn);
 
         // \Sentry\trace() is a no-op without an active transaction (see
-        // init.php's per-request transaction, sampled at 10%).
-        $spanContext = new SpanContext();
-        $spanContext->setOp('db.query');
-        $spanContext->setDescription($this->sql_span_description($sql));
-        \Sentry\trace(function () use ($q, $sql) {
+        // init.php's per-request transaction, sampled at 10%) - skip
+        // building a SpanContext at all in that case (most requests), rather
+        // than doing that work just to have \Sentry\trace() discard it.
+        if (SentrySdk::getCurrentHub()->getSpan()) {
+            $spanContext = new SpanContext();
+            $spanContext->setOp('db.query');
+            $spanContext->setDescription($this->sql_span_description($sql));
+            \Sentry\trace(function () use ($q, $sql) {
+                $q->query($sql);
+            }, $spanContext);
+        } else {
             $q->query($sql);
-        }, $spanContext);
+        }
 
         $duration = getmicrotime() - $start;
         global $mysqltotalduration;

--- a/www/includes/mysql.php
+++ b/www/includes/mysql.php
@@ -399,6 +399,26 @@ class MySQL {
     }
 
     /**
+     * Sentry span description: query shape only (verb + table), never the
+     * literal SQL - $sql may already contain real parameter values.
+     */
+    protected function sql_span_description(string $sql): string {
+        if (preg_match('/^\s*SELECT\b.*?\bFROM\s+`?(\w+)`?/is', $sql, $matches)) {
+            return 'SELECT ' . $matches[1];
+        }
+        if (preg_match('/^\s*(INSERT|REPLACE)\s+INTO\s+`?(\w+)`?/i', $sql, $matches)) {
+            return strtoupper($matches[1]) . ' ' . $matches[2];
+        }
+        if (preg_match('/^\s*UPDATE\s+`?(\w+)`?/i', $sql, $matches)) {
+            return 'UPDATE ' . $matches[1];
+        }
+        if (preg_match('/^\s*DELETE\s+FROM\s+`?(\w+)`?/i', $sql, $matches)) {
+            return 'DELETE ' . $matches[1];
+        }
+        return preg_match('/^\s*(\w+)/', $sql, $matches) ? strtoupper($matches[1]) : 'query';
+    }
+
+    /**
      *
      */
     public function query($sql, ...$params) {
@@ -415,12 +435,10 @@ class MySQL {
         $q = new MySQLQuery($this->conn);
 
         // \Sentry\trace() is a no-op without an active transaction (see
-        // init.php's per-request transaction, sampled at 10%) - kept here
-        // rather than at each call site so every query is covered regardless
-        // of entry point.
+        // init.php's per-request transaction, sampled at 10%).
         $spanContext = new SpanContext();
         $spanContext->setOp('db.query');
-        $spanContext->setDescription($sql);
+        $spanContext->setDescription($this->sql_span_description($sql));
         \Sentry\trace(function () use ($q, $sql) {
             $q->query($sql);
         }, $spanContext);

--- a/www/includes/mysql.php
+++ b/www/includes/mysql.php
@@ -100,6 +100,8 @@
  * $q->affected_rows() returns NULL.
  */
 
+use Sentry\Tracing\SpanContext;
+
 // We'll add up the times of each query so we can output the page total at the end.
 global $mysqltotalduration;
 $mysqltotalduration = 0.0;
@@ -411,7 +413,17 @@ class MySQL {
 
         $start = getmicrotime();
         $q = new MySQLQuery($this->conn);
-        $q->query($sql);
+
+        // \Sentry\trace() is a no-op without an active transaction (see
+        // init.php's per-request transaction, sampled at 10%) - kept here
+        // rather than at each call site so every query is covered regardless
+        // of entry point.
+        $spanContext = new SpanContext();
+        $spanContext->setOp('db.query');
+        $spanContext->setDescription($sql);
+        \Sentry\trace(function () use ($q, $sql) {
+            $q->query($sql);
+        }, $spanContext);
 
         $duration = getmicrotime() - $start;
         global $mysqltotalduration;

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -5,6 +5,7 @@
  * General utility functions v1.1 (well, it was). *
  */
 
+use Sentry\Severity;
 use Sentry\Tracing\SpanStatus;
 use Sentry\SentrySdk;
 use Sentry\Tracing\TransactionContext;
@@ -810,6 +811,13 @@ function send_email($to, $subject, $message, $bulk = false) {
 
     try {
         $success = mail($to, $subject, $message, $headers);
+
+        if (!$success) {
+            \Sentry\withScope(function ($scope) use ($bulk) {
+                $scope->setTag('bulk', $bulk ? 'true' : 'false');
+                \Sentry\captureMessage('mail() failed', Severity::warning());
+            });
+        }
     } finally {
         $transaction->setTags(['bulk' => $bulk ? 'true' : 'false']);
         $transaction->setStatus($success ?? false ? SpanStatus::ok() : SpanStatus::internalError());

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -5,6 +5,10 @@
  * General utility functions v1.1 (well, it was). *
  */
 
+use Sentry\Tracing\SpanStatus;
+use Sentry\SentrySdk;
+use Sentry\Tracing\TransactionContext;
+
 include_once __DIR__ . '/strptime.php';
 
 /**
@@ -793,7 +797,22 @@ function send_email($to, $subject, $message, $bulk = false) {
      */
     twfy_debug('EMAIL', "Sending email to $to with subject of '$subject'");
 
+    // A standalone transaction, not a \Sentry\trace() child span of
+    // init.php's per-request one: that transaction is only 10% sampled, and
+    // may not exist at all outside a request (eg a script that calls this
+    // directly). Email sending is comparatively rare - every send should be
+    // counted, not a sample of them - so this starts and finishes its own
+    // transaction regardless, visible in Sentry's Insights/Trace Explorer.
+    $transactionContext = new TransactionContext('email.send');
+    $transactionContext->setOp('email.send');
+    $transaction = \Sentry\startTransaction($transactionContext);
+    SentrySdk::getCurrentHub()->setSpan($transaction);
+
     $success = mail($to, $subject, $message, $headers);
+
+    $transaction->setTags(['bulk' => $bulk ? 'true' : 'false']);
+    $transaction->setStatus($success ? SpanStatus::ok() : SpanStatus::internalError());
+    $transaction->finish();
 
     return $success;
 }

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -797,22 +797,25 @@ function send_email($to, $subject, $message, $bulk = false) {
      */
     twfy_debug('EMAIL', "Sending email to $to with subject of '$subject'");
 
-    // A standalone transaction, not a \Sentry\trace() child span of
-    // init.php's per-request one: that transaction is only 10% sampled, and
-    // may not exist at all outside a request (eg a script that calls this
-    // directly). Email sending is comparatively rare - every send should be
-    // counted, not a sample of them - so this starts and finishes its own
-    // transaction regardless, visible in Sentry's Insights/Trace Explorer.
+    // Standalone transaction, explicitly sampled (every send counted, not a
+    // 10% sample), restoring the previous span afterward.
     $transactionContext = new TransactionContext('email.send');
     $transactionContext->setOp('email.send');
+    $transactionContext->setSampled(true);
     $transaction = \Sentry\startTransaction($transactionContext);
-    SentrySdk::getCurrentHub()->setSpan($transaction);
 
-    $success = mail($to, $subject, $message, $headers);
+    $hub = SentrySdk::getCurrentHub();
+    $previousSpan = $hub->getSpan();
+    $hub->setSpan($transaction);
 
-    $transaction->setTags(['bulk' => $bulk ? 'true' : 'false']);
-    $transaction->setStatus($success ? SpanStatus::ok() : SpanStatus::internalError());
-    $transaction->finish();
+    try {
+        $success = mail($to, $subject, $message, $headers);
+    } finally {
+        $transaction->setTags(['bulk' => $bulk ? 'true' : 'false']);
+        $transaction->setStatus($success ?? false ? SpanStatus::ok() : SpanStatus::internalError());
+        $transaction->finish();
+        $hub->setSpan($previousSpan);
+    }
 
     return $success;
 }

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -173,7 +173,6 @@ function error_handler(string $errno, string $errmsg, string $filename, int $lin
         } else {
             print "<p>Oops, sorry, an error has occurred!</p>\n";
         }
-        // TODO add honey badger.
     }
 
     // Do we need to exit?


### PR DESCRIPTION
## What and why

We want to keep an eye on how many emails we send and how much load our database queries put on things. This adds that tracking to Sentry.

Every email goes through one function (`send_email`), so it now reports each send to Sentry, tagged as bulk or one-off, and flags failures too. Every database query goes through one function too (`MySQL::query`), so it's now tracked the same way, at a 10% sample rate to keep costs down on a public site.

A few rounds of review found real problems, now fixed: query text was going to Sentry with real parameter values still in it (emails, postcodes, search terms), the email transaction wasn't actually being sampled so most sends would've been dropped, and a finished transaction wasn't being cleared off the current span.

## Type of change

- [x] New feature

## How this was checked

- [x] Ran the automated tests (345/345 passing)
- [x] phpcs and php -l clean
- [ ] SonarCloud's coverage gate is failing (~40% on new code) and will likely stay that way. The uncovered lines are in two places:
  - `init.php`'s per-request transaction only runs when `SENTRY_DSN` is set, which it never is in test config - the block just doesn't execute during a test run.
  - `send_email()`'s Sentry calls are gated behind PHP's global `mail()` function, which has no mocking mechanism available in this codebase (no runkit/uopz, and this file isn't namespaced so we can't shadow it).

  Both are orchestration code wired to real infrastructure, not logic worth unit-testing in isolation - same call as an earlier PR's gap in `hansard_gid.php`.

Assisted-by: Claude Code:claude-sonnet-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring**
  - Improved performance monitoring for web and command-line requests.
  - Added tracing for database activity to help identify query-related slowdowns.
  - Enhanced visibility into email delivery operations, including successful and failed attempts.
  - Request, database, and email activity is now correlated for faster troubleshooting and more reliable service diagnostics.

- **Tests**
  - Added coverage for database queries with and without active tracing.
  - Expanded validation of SQL operation descriptions and protection of sensitive query values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->